### PR TITLE
Update endpoint for worker v2.11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   lint:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-whatsapp-gateway",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ app.post('/meta-whatsapp', async (c) => {
  *
  * Because JS is single-threaded, the synchronous get()+set() below is atomic
  * within an isolate — no concurrent request can interleave between check and
- * mark. Cross-isolate dedup is handled by the worker's UserQueue DO which
+ * mark. Cross-isolate dedup is handled by the worker's UserDO which
  * serializes processing per-user. Expired entries are swept periodically
  * (at most once per SWEEP_INTERVAL_MS) so the map doesn't grow unbounded.
  */

--- a/src/services/engine-client.ts
+++ b/src/services/engine-client.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Env } from '../config/types';
-import type { MessageRequest, QueuedResponse } from '../types/engine';
+import type { MessageRequest, ChatResponse } from '../types/engine';
 import { logger } from '../utils/logger';
 
 /** Client identifier for this gateway */
@@ -32,7 +32,7 @@ export interface SendMessageOptions {
 }
 
 /**
- * Send a message to the engine for queued processing.
+ * Send a message to the engine for processing.
  */
 export async function sendMessage(
   userId: string,
@@ -40,8 +40,8 @@ export async function sendMessage(
   env: Env,
   messageKey: string,
   options?: SendMessageOptions
-): Promise<QueuedResponse | null> {
-  const url = `${env.ENGINE_BASE_URL}/api/v1/chat/queue`;
+): Promise<ChatResponse | null> {
+  const url = `${env.ENGINE_BASE_URL}/api/v1/chat`;
   const { progressCallbackUrl, audio } = options ?? {};
 
   const payload: MessageRequest = {
@@ -77,7 +77,7 @@ export async function sendMessage(
       return null;
     }
 
-    return (await response.json()) as QueuedResponse;
+    return (await response.json()) as ChatResponse;
   } catch (error) {
     logger.error('Engine connection error', {
       error: error instanceof Error ? error.message : String(error),

--- a/src/services/message-handler.ts
+++ b/src/services/message-handler.ts
@@ -218,9 +218,8 @@ async function processMessage(raw: RawMessage, contacts: Contact[], env: Env): P
     return;
   }
 
-  logger.info('Message queued', {
+  logger.info('Message accepted', {
     messageId: result.message_id,
-    queuePosition: result.queue_position,
   });
 }
 

--- a/src/services/message-handler.ts
+++ b/src/services/message-handler.ts
@@ -209,7 +209,7 @@ async function processMessage(raw: RawMessage, contacts: Contact[], env: Env): P
   const result = await sendToEngine(message.userId, messageText, env, message.messageId, options);
 
   if (!result) {
-    logger.error('Failed to queue message with engine');
+    logger.error('Failed to send message to engine');
     await sendToWhatsApp(
       message.userId,
       'Sorry, I encountered an error processing your message. Please try again.',

--- a/src/types/engine.ts
+++ b/src/types/engine.ts
@@ -2,7 +2,7 @@
  * Types for communicating with the BT Servant Engine API.
  */
 
-/** Request body for the /api/v1/chat/queue endpoint */
+/** Request body for the /api/v1/chat endpoint */
 export interface MessageRequest {
   client_id: string;
   user_id: string;
@@ -17,10 +17,9 @@ export interface MessageRequest {
   audio_format?: string;
 }
 
-/** Response from the /api/v1/chat/queue endpoint */
-export interface QueuedResponse {
+/** Response from the /api/v1/chat endpoint */
+export interface ChatResponse {
   message_id: string;
-  queue_position: number;
 }
 
 /** Callback type discriminator from the engine */

--- a/tests/unit/engine-client.test.ts
+++ b/tests/unit/engine-client.test.ts
@@ -36,7 +36,6 @@ describe('engine-client', () => {
     it('should send a message successfully', async () => {
       const mockResponse = {
         message_id: 'msg-123',
-        queue_position: 0,
       };
 
       fetchMock.mockResolvedValueOnce({
@@ -48,7 +47,7 @@ describe('engine-client', () => {
 
       expect(result).toEqual(mockResponse);
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://localhost:8787/api/v1/chat/queue',
+        'http://localhost:8787/api/v1/chat',
         expect.objectContaining({
           method: 'POST',
           headers: {
@@ -70,7 +69,6 @@ describe('engine-client', () => {
     it('should include progress callback and mode when url provided', async () => {
       const mockResponse = {
         message_id: 'msg-456',
-        queue_position: 1,
       };
 
       fetchMock.mockResolvedValueOnce({
@@ -83,7 +81,7 @@ describe('engine-client', () => {
       });
 
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://localhost:8787/api/v1/chat/queue',
+        'http://localhost:8787/api/v1/chat',
         expect.objectContaining({
           body: JSON.stringify({
             client_id: 'whatsapp',
@@ -103,7 +101,6 @@ describe('engine-client', () => {
     it('should not include progress callback when url not provided', async () => {
       const mockResponse = {
         message_id: 'msg-789',
-        queue_position: 0,
       };
 
       fetchMock.mockResolvedValueOnce({
@@ -114,7 +111,7 @@ describe('engine-client', () => {
       await sendMessage('user123', 'Hi there', mockEnv, 'wamid.abc123');
 
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://localhost:8787/api/v1/chat/queue',
+        'http://localhost:8787/api/v1/chat',
         expect.objectContaining({
           body: JSON.stringify({
             client_id: 'whatsapp',
@@ -149,7 +146,7 @@ describe('engine-client', () => {
     });
 
     it('should send audio message with audio payload', async () => {
-      const mockResponse = { message_id: 'msg-audio', queue_position: 0 };
+      const mockResponse = { message_id: 'msg-audio' };
       fetchMock.mockResolvedValueOnce({ ok: true, json: async () => mockResponse });
 
       const audio = { audioBase64: 'dGVzdA==', audioFormat: 'ogg' };
@@ -157,7 +154,7 @@ describe('engine-client', () => {
 
       expect(result).toEqual(mockResponse);
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://localhost:8787/api/v1/chat/queue',
+        'http://localhost:8787/api/v1/chat',
         expect.objectContaining({
           body: JSON.stringify({
             client_id: 'whatsapp',
@@ -173,7 +170,7 @@ describe('engine-client', () => {
     });
 
     it('should send audio message with progress callback', async () => {
-      const mockResponse = { message_id: 'msg-audio2', queue_position: 0 };
+      const mockResponse = { message_id: 'msg-audio2' };
       fetchMock.mockResolvedValueOnce({ ok: true, json: async () => mockResponse });
 
       const audio = { audioBase64: 'dGVzdA==', audioFormat: 'ogg' };
@@ -183,7 +180,7 @@ describe('engine-client', () => {
       });
 
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://localhost:8787/api/v1/chat/queue',
+        'http://localhost:8787/api/v1/chat',
         expect.objectContaining({
           body: JSON.stringify({
             client_id: 'whatsapp',


### PR DESCRIPTION
## Summary
- Rename `QueuedResponse` → `ChatResponse` and remove the deprecated `queue_position` field
- Switch endpoint from `/api/v1/chat/queue` to `/api/v1/chat` to match worker v2.11.0's merged `UserDO`
- Bump version to 1.2.0

Closes #16

## Test plan
- [x] `pnpm lint` — 0 errors
- [x] `pnpm check` — clean
- [x] `pnpm test` — 96/96 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)