### PR TITLE
Migrate chat endpoint to /api/v1/chat/callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ bt-servant-whatsapp-gateway/
 2. **Immediate Response**: Gateway returns 200 immediately (waitUntil pattern)
 3. **Validation**: In background, verifies the signature and user agent
 4. **Message Parsing**: Extracts message content (text and voice/audio)
-5. **Engine Request**: Sends message to engine's `/api/v1/chat` endpoint with callback URL
+5. **Engine Request**: Sends message to engine's `/api/v1/chat/callback` endpoint with callback URL
 6. **Progress Updates**: Engine sends progress updates to `/progress-callback` during processing
 7. **Response Processing**: Engine returns text response
 8. **Chunking**: Long responses are split into WhatsApp-friendly chunks (≤1500 chars)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-whatsapp-gateway",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/services/engine-client.ts
+++ b/src/services/engine-client.ts
@@ -41,7 +41,7 @@ export async function sendMessage(
   messageKey: string,
   options?: SendMessageOptions
 ): Promise<ChatResponse | null> {
-  const url = `${env.ENGINE_BASE_URL}/api/v1/chat`;
+  const url = `${env.ENGINE_BASE_URL}/api/v1/chat/callback`;
   const { progressCallbackUrl, audio } = options ?? {};
 
   const payload: MessageRequest = {

--- a/tests/unit/engine-client.test.ts
+++ b/tests/unit/engine-client.test.ts
@@ -47,7 +47,7 @@ describe('engine-client', () => {
 
       expect(result).toEqual(mockResponse);
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://localhost:8787/api/v1/chat',
+        'http://localhost:8787/api/v1/chat/callback',
         expect.objectContaining({
           method: 'POST',
           headers: {
@@ -81,7 +81,7 @@ describe('engine-client', () => {
       });
 
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://localhost:8787/api/v1/chat',
+        'http://localhost:8787/api/v1/chat/callback',
         expect.objectContaining({
           body: JSON.stringify({
             client_id: 'whatsapp',
@@ -111,7 +111,7 @@ describe('engine-client', () => {
       await sendMessage('user123', 'Hi there', mockEnv, 'wamid.abc123');
 
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://localhost:8787/api/v1/chat',
+        'http://localhost:8787/api/v1/chat/callback',
         expect.objectContaining({
           body: JSON.stringify({
             client_id: 'whatsapp',
@@ -154,7 +154,7 @@ describe('engine-client', () => {
 
       expect(result).toEqual(mockResponse);
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://localhost:8787/api/v1/chat',
+        'http://localhost:8787/api/v1/chat/callback',
         expect.objectContaining({
           body: JSON.stringify({
             client_id: 'whatsapp',
@@ -180,7 +180,7 @@ describe('engine-client', () => {
       });
 
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://localhost:8787/api/v1/chat',
+        'http://localhost:8787/api/v1/chat/callback',
         expect.objectContaining({
           body: JSON.stringify({
             client_id: 'whatsapp',


### PR DESCRIPTION
## Summary

- Repoint the gateway's outbound worker call from `POST /api/v1/chat` to `POST /api/v1/chat/callback` (available in `bt-servant-worker` v2.13.0+).
- Update the 5 mocked URL assertions in `tests/unit/engine-client.test.ts`, the flow description in `README.md`, and bump `package.json` to `1.2.1`.
- No behavior change — request body shape is unchanged (`progress_callback_url` + `message_key` are still required on `/chat/callback`), and the `/progress-callback` receiver route and callback payload shape are unaffected.

## Why now

`bt-servant-worker` v2.14.0 (breaking) will make `/api/v1/chat` final-only JSON and **reject** any request containing `progress_callback_url` with a 400. This PR must land before v2.14.0 ships — per issue #18, within ~1 week of v2.13.0.

Closes #18

## Test plan

- [x] `pnpm lint` — 0 errors (3 pre-existing warnings unrelated to this change)
- [x] `pnpm check` — clean
- [x] `pnpm test` — 96/96 passing
- [ ] End-to-end against local `wrangler dev` of `bt-servant-worker` latest `main` (v2.13.0+): send a real WhatsApp message and confirm the gateway POSTs to `/api/v1/chat/callback`, the worker returns 202, and progress/complete callbacks still arrive at `/progress-callback` with the same payload shape
- [ ] Repeat end-to-end with an audio message
- [ ] Inspect the 202 body to confirm whether it still contains `message_id` — if not, follow up to adjust the "Message accepted" log line at `src/services/message-handler.ts:222`
- [ ] Deploy to production **before** worker v2.14.0 ships
- [ ] Post confirmation comment on #18 once prod smoke test passes