### PR TITLE
HEAD-precheck media URLs against Meta's size caps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-whatsapp-gateway",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/services/message-handler.ts
+++ b/src/services/message-handler.ts
@@ -21,7 +21,7 @@ import {
   downloadMedia,
 } from './meta-api/client';
 import { extractMedia, MAX_CAPTION_LENGTH } from './media-extractor';
-import type { MediaAttachment } from './media-extractor';
+import type { MediaAttachment, MediaKind } from './media-extractor';
 import { sendMessage as sendToEngine } from './engine-client';
 import type { AudioPayload, SendMessageOptions } from './engine-client';
 import { chunkMessage } from './chunking';
@@ -347,6 +347,43 @@ async function tryAudioDelivery(callback: EngineCallback, env: Env): Promise<boo
   return false;
 }
 
+/** Meta WhatsApp Cloud API per-link size caps. */
+const META_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
+const META_VIDEO_MAX_BYTES = 16 * 1024 * 1024;
+
+/**
+ * HEAD-check the source URL to decide whether Meta will accept it as inline
+ * media. Lenient: `unknown` lets the send proceed (matches today's behavior).
+ * Only `too_large` blocks the inline attempt.
+ */
+async function precheckMediaSize(
+  url: string,
+  kind: MediaKind
+): Promise<'ok' | 'too_large' | 'unknown'> {
+  const limit = kind === 'video' ? META_VIDEO_MAX_BYTES : META_IMAGE_MAX_BYTES;
+  try {
+    const response = await fetch(url, { method: 'HEAD', redirect: 'follow' });
+    if (!response.ok) {
+      logger.warn('Media precheck HEAD non-2xx', {
+        url: redactUrl(url),
+        status: response.status,
+      });
+      return 'unknown';
+    }
+    const lenHeader = response.headers.get('Content-Length');
+    if (!lenHeader) return 'unknown';
+    const size = parseInt(lenHeader, 10);
+    if (Number.isNaN(size)) return 'unknown';
+    return size > limit ? 'too_large' : 'ok';
+  } catch (err) {
+    logger.warn('Media precheck HEAD failed', {
+      url: redactUrl(url),
+      error: String(err),
+    });
+    return 'unknown';
+  }
+}
+
 async function sendOneAttachment(
   userId: string,
   attachment: MediaAttachment,
@@ -359,13 +396,37 @@ async function sendOneAttachment(
   return sendVideoMessage(userId, attachment.url, caption, env);
 }
 
+/**
+ * Pre-check the source URL size before attempting an inline media send.
+ * Returns false if the file is known to exceed Meta's per-link cap (the
+ * caller's existing fallback path will degrade gracefully) — Meta returns
+ * 200 even for oversized links and silently drops delivery, so we have to
+ * catch this client-side. Returns true otherwise.
+ */
+async function trySendAttachmentChecked(
+  userId: string,
+  attachment: MediaAttachment,
+  caption: string | undefined,
+  env: Env
+): Promise<boolean> {
+  const status = await precheckMediaSize(attachment.url, attachment.kind);
+  if (status === 'too_large') {
+    logger.warn('Media exceeds Meta inline-link size limit, skipping media send', {
+      kind: attachment.kind,
+      url: redactUrl(attachment.url),
+    });
+    return false;
+  }
+  return sendOneAttachment(userId, attachment, caption, env);
+}
+
 async function sendRemainingAttachments(
   userId: string,
   attachments: MediaAttachment[],
   env: Env
 ): Promise<void> {
   for (const attachment of attachments) {
-    const sent = await sendOneAttachment(userId, attachment, undefined, env);
+    const sent = await trySendAttachmentChecked(userId, attachment, undefined, env);
     if (sent) {
       logger.info('Sent media attachment', {
         kind: attachment.kind,
@@ -392,7 +453,7 @@ async function sendInCaptionMode(
 ): Promise<void> {
   const first = attachments[0];
   if (!first) return;
-  const firstSent = await sendOneAttachment(callback.user_id, first, captionText, env);
+  const firstSent = await trySendAttachmentChecked(callback.user_id, first, captionText, env);
   if (!firstSent) {
     logger.warn('First media send failed, falling back to text', {
       kind: first.kind,

--- a/src/services/message-handler.ts
+++ b/src/services/message-handler.ts
@@ -351,18 +351,39 @@ async function tryAudioDelivery(callback: EngineCallback, env: Env): Promise<boo
 const META_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
 const META_VIDEO_MAX_BYTES = 16 * 1024 * 1024;
 
+/** HEAD-precheck request timeout. Bounds the outbound side-effect surface. */
+const PRECHECK_TIMEOUT_MS = 3000;
+
+/** Identifying User-Agent so target servers can attribute / throttle our HEADs. */
+const PRECHECK_USER_AGENT = 'bt-servant-whatsapp-gateway/precheck (+meta-link-size-check)';
+
 /**
  * HEAD-check the source URL to decide whether Meta will accept it as inline
  * media. Lenient: `unknown` lets the send proceed (matches today's behavior).
  * Only `too_large` blocks the inline attempt.
+ *
+ * Threat model: this introduces an outbound HEAD against URLs that originated
+ * in LLM-generated text. The surface is bounded by:
+ *  - HTTPS-only (extractor regex)
+ *  - HEAD method (no response body returned to caller; size cap on parsed length)
+ *  - Cloudflare Workers egress: public internet only, no RFC1918 / link-local
+ *  - Hard timeout below to bound DoS / slow-loris by hostile targets
+ *  - Identifying User-Agent so the target can attribute / throttle us
  */
 async function precheckMediaSize(
   url: string,
   kind: MediaKind
 ): Promise<'ok' | 'too_large' | 'unknown'> {
   const limit = kind === 'video' ? META_VIDEO_MAX_BYTES : META_IMAGE_MAX_BYTES;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PRECHECK_TIMEOUT_MS);
   try {
-    const response = await fetch(url, { method: 'HEAD', redirect: 'follow' });
+    const response = await fetch(url, {
+      method: 'HEAD',
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: { 'User-Agent': PRECHECK_USER_AGENT },
+    });
     if (!response.ok) {
       logger.warn('Media precheck HEAD non-2xx', {
         url: redactUrl(url),
@@ -381,6 +402,8 @@ async function precheckMediaSize(
       error: String(err),
     });
     return 'unknown';
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/tests/unit/handle-callback-media.test.ts
+++ b/tests/unit/handle-callback-media.test.ts
@@ -251,4 +251,31 @@ describe('handleEngineCallback with inline media', () => {
     expect(posts).toHaveLength(1);
     expect(posts[0].type).toBe('image');
   });
+
+  it('proceeds with inline media send when HEAD throws (timeout or network error)', async () => {
+    // Simulate the AbortController timeout or an underlying network failure.
+    // Must not stall or regress behavior; falls through to the lenient path.
+    fetchMock
+      .mockRejectedValueOnce(new Error('The operation was aborted'))
+      .mockResolvedValueOnce({ ok: true });
+
+    const text = 'Slow server image:\nhttps://cdn.example.com/pic.jpg\nfinally.';
+    await handleEngineCallback(baseCallback(text), mockEnv);
+
+    const posts = metaPosts(fetchMock);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].type).toBe('image');
+  });
+
+  it('sends a User-Agent identifying the precheck on HEAD requests', async () => {
+    fetchMock.mockResolvedValueOnce(HEAD_UNKNOWN).mockResolvedValueOnce({ ok: true });
+
+    const text = 'Image:\nhttps://cdn.example.com/pic.jpg';
+    await handleEngineCallback(baseCallback(text), mockEnv);
+
+    const headCall = fetchMock.mock.calls.find((c) => c[1]?.method === 'HEAD');
+    expect(headCall).toBeDefined();
+    const ua = (headCall?.[1]?.headers as Record<string, string> | undefined)?.['User-Agent'];
+    expect(ua).toMatch(/bt-servant-whatsapp-gateway/);
+  });
 });

--- a/tests/unit/handle-callback-media.test.ts
+++ b/tests/unit/handle-callback-media.test.ts
@@ -29,9 +29,18 @@ function baseCallback(text: string): EngineCallback {
   };
 }
 
-function lastCallBody(fetchMock: ReturnType<typeof vi.fn>, idx: number): Record<string, unknown> {
-  const call = fetchMock.mock.calls[idx];
-  return JSON.parse(call[1]?.body as string);
+/** Response shape for a HEAD precheck that should pass through as 'unknown'. */
+const HEAD_UNKNOWN = { ok: true, headers: new Headers() };
+/** Build a HEAD response with an explicit Content-Length. */
+function headWithLength(bytes: number) {
+  return { ok: true, headers: new Headers({ 'Content-Length': String(bytes) }) };
+}
+
+/** Filter the mocked fetch call list down to Meta JSON POSTs only (skips HEAD prechecks and multipart uploads). */
+function metaPosts(fetchMock: ReturnType<typeof vi.fn>): Array<Record<string, unknown>> {
+  return fetchMock.mock.calls
+    .filter((c) => (c[1]?.method ?? 'GET') === 'POST' && typeof c[1]?.body === 'string')
+    .map((c) => JSON.parse(c[1].body as string));
 }
 
 describe('handleEngineCallback with inline media', () => {
@@ -48,62 +57,65 @@ describe('handleEngineCallback with inline media', () => {
   });
 
   it('sends image message with stripped caption when text has one jpg URL', async () => {
-    fetchMock.mockResolvedValueOnce({ ok: true });
+    fetchMock.mockResolvedValueOnce(HEAD_UNKNOWN).mockResolvedValueOnce({ ok: true });
 
     const text = 'Check this out:\nhttps://cdn.example.com/pic.jpg\n\nIsn’t it beautiful?';
     await handleEngineCallback(baseCallback(text), mockEnv);
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const body = lastCallBody(fetchMock, 0);
-    expect(body.type).toBe('image');
-    expect(body.image).toEqual({
+    const posts = metaPosts(fetchMock);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].type).toBe('image');
+    expect(posts[0].image).toEqual({
       link: 'https://cdn.example.com/pic.jpg',
       caption: 'Check this out:\n\nIsn’t it beautiful?',
     });
   });
 
   it('sends video message with stripped caption when text has one mp4 URL', async () => {
-    fetchMock.mockResolvedValueOnce({ ok: true });
+    fetchMock.mockResolvedValueOnce(HEAD_UNKNOWN).mockResolvedValueOnce({ ok: true });
 
     const text = 'Here is a video:\nhttps://cdn.example.com/clip.mp4\n\nEnjoy!';
     await handleEngineCallback(baseCallback(text), mockEnv);
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const body = lastCallBody(fetchMock, 0);
-    expect(body.type).toBe('video');
-    expect(body.video).toEqual({
+    const posts = metaPosts(fetchMock);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].type).toBe('video');
+    expect(posts[0].video).toEqual({
       link: 'https://cdn.example.com/clip.mp4',
       caption: 'Here is a video:\n\nEnjoy!',
     });
   });
 
   it('sends two media messages with caption on first only when text has two URLs', async () => {
-    fetchMock.mockResolvedValueOnce({ ok: true }).mockResolvedValueOnce({ ok: true });
+    fetchMock
+      .mockResolvedValueOnce(HEAD_UNKNOWN)
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(HEAD_UNKNOWN)
+      .mockResolvedValueOnce({ ok: true });
 
     const text = 'Two things:\nhttps://cdn.example.com/a.jpg\nhttps://cdn.example.com/b.mp4\nDone.';
     await handleEngineCallback(baseCallback(text), mockEnv);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-
-    const first = lastCallBody(fetchMock, 0);
-    expect(first.type).toBe('image');
-    expect((first.image as Record<string, unknown>).caption).toBe('Two things:\n\nDone.');
-
-    const second = lastCallBody(fetchMock, 1);
-    expect(second.type).toBe('video');
-    expect((second.video as Record<string, unknown>).caption).toBeUndefined();
+    const posts = metaPosts(fetchMock);
+    expect(posts).toHaveLength(2);
+    expect(posts[0].type).toBe('image');
+    expect((posts[0].image as Record<string, unknown>).caption).toBe('Two things:\n\nDone.');
+    expect(posts[1].type).toBe('video');
+    expect((posts[1].video as Record<string, unknown>).caption).toBeUndefined();
   });
 
   it('falls back to original text when the first (caption-bearing) media fails', async () => {
     fetchMock
+      .mockResolvedValueOnce(HEAD_UNKNOWN)
       .mockResolvedValueOnce({ ok: false, status: 400, text: async () => 'Bad Request' })
       .mockResolvedValueOnce({ ok: true });
 
     const text = 'Look:\nhttps://cdn.example.com/broken.jpg\nMoving on.';
     await handleEngineCallback(baseCallback(text), mockEnv);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    const fallback = lastCallBody(fetchMock, 1);
+    const posts = metaPosts(fetchMock);
+    expect(posts).toHaveLength(2);
+    const fallback = posts[1];
     expect(fallback.type).toBe('text');
     expect((fallback.text as Record<string, unknown>).body).toBe(text);
   });
@@ -113,47 +125,40 @@ describe('handleEngineCallback with inline media', () => {
     // but the failed URL was stripped from the caption so we send just the URL
     // as plain text to preserve the clickable link.
     fetchMock
+      .mockResolvedValueOnce(HEAD_UNKNOWN)
       .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(HEAD_UNKNOWN)
       .mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'Server Error' })
       .mockResolvedValueOnce({ ok: true });
 
     const text = 'Two things:\nhttps://cdn.example.com/a.jpg\nhttps://cdn.example.com/b.mp4\nDone.';
     await handleEngineCallback(baseCallback(text), mockEnv);
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-
-    // First: image with caption.
-    const first = lastCallBody(fetchMock, 0);
-    expect(first.type).toBe('image');
-    expect((first.image as Record<string, unknown>).caption).toBe('Two things:\n\nDone.');
-
-    // Second: failed video attempt.
-    const second = lastCallBody(fetchMock, 1);
-    expect(second.type).toBe('video');
-
-    // Third: the URL of the failed media, sent as plain text — NOT the full
-    // original text (which would duplicate the caption).
-    const third = lastCallBody(fetchMock, 2);
-    expect(third.type).toBe('text');
-    expect((third.text as Record<string, unknown>).body).toBe('https://cdn.example.com/b.mp4');
+    const posts = metaPosts(fetchMock);
+    expect(posts).toHaveLength(3);
+    expect(posts[0].type).toBe('image');
+    expect((posts[0].image as Record<string, unknown>).caption).toBe('Two things:\n\nDone.');
+    expect(posts[1].type).toBe('video');
+    expect(posts[2].type).toBe('text');
+    expect((posts[2].text as Record<string, unknown>).body).toBe('https://cdn.example.com/b.mp4');
   });
 
   it('sends media captionless and full text separately when stripped text exceeds 1024 chars', async () => {
-    fetchMock.mockResolvedValueOnce({ ok: true }).mockResolvedValueOnce({ ok: true });
+    fetchMock
+      .mockResolvedValueOnce(HEAD_UNKNOWN)
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: true });
 
     const filler = 'a'.repeat(1100);
     const text = `${filler}\n\nhttps://cdn.example.com/pic.jpg\n\ntrailing`;
     await handleEngineCallback(baseCallback(text), mockEnv);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-
-    const mediaCall = lastCallBody(fetchMock, 0);
-    expect(mediaCall.type).toBe('image');
-    expect((mediaCall.image as Record<string, unknown>).caption).toBeUndefined();
-
-    const textCall = lastCallBody(fetchMock, 1);
-    expect(textCall.type).toBe('text');
-    const body = (textCall.text as Record<string, unknown>).body as string;
+    const posts = metaPosts(fetchMock);
+    expect(posts).toHaveLength(2);
+    expect(posts[0].type).toBe('image');
+    expect((posts[0].image as Record<string, unknown>).caption).toBeUndefined();
+    expect(posts[1].type).toBe('text');
+    const body = (posts[1].text as Record<string, unknown>).body as string;
     expect(body).toContain(filler);
     expect(body).toContain('trailing');
     expect(body).not.toContain('https://cdn.example.com/pic.jpg');
@@ -165,10 +170,10 @@ describe('handleEngineCallback with inline media', () => {
     const text = 'Plain old text response, no media at all.';
     await handleEngineCallback(baseCallback(text), mockEnv);
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const body = lastCallBody(fetchMock, 0);
-    expect(body.type).toBe('text');
-    expect((body.text as Record<string, unknown>).body).toBe(text);
+    const posts = metaPosts(fetchMock);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].type).toBe('text');
+    expect((posts[0].text as Record<string, unknown>).body).toBe(text);
   });
 
   it('does not attempt media extraction when audio delivery succeeds', async () => {
@@ -189,14 +194,61 @@ describe('handleEngineCallback with inline media', () => {
     await handleEngineCallback(callback, mockEnv);
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    // The audio send is by id, so no image/video call should be present.
-    for (const call of fetchMock.mock.calls) {
-      const init = call[1];
-      if (init?.body && typeof init.body === 'string') {
-        const parsed = JSON.parse(init.body);
-        expect(parsed.type).not.toBe('image');
-        expect(parsed.type).not.toBe('video');
-      }
+    for (const post of metaPosts(fetchMock)) {
+      expect(post.type).not.toBe('image');
+      expect(post.type).not.toBe('video');
     }
+  });
+
+  it('skips inline media send and falls back to original text when first attachment is too large', async () => {
+    // Caption-mode first attachment is over Meta's 16 MB video cap → precheck
+    // returns 'too_large' → inline send is skipped → fall back to sending the
+    // original un-stripped text so the user sees the URL as a clickable link.
+    fetchMock
+      .mockResolvedValueOnce(headWithLength(40 * 1024 * 1024))
+      .mockResolvedValueOnce({ ok: true });
+
+    const text = 'Big video:\nhttps://cdn.example.com/huge.mp4\nWatch carefully.';
+    await handleEngineCallback(baseCallback(text), mockEnv);
+
+    const posts = metaPosts(fetchMock);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].type).toBe('text');
+    expect((posts[0].text as Record<string, unknown>).body).toBe(text);
+  });
+
+  it('sends URL as text for a non-first attachment that is too large, while sending the OK ones inline', async () => {
+    // First (image, small) → media send with caption.
+    // Second (video, oversized) → precheck blocks inline; URL goes out as text.
+    fetchMock
+      .mockResolvedValueOnce(headWithLength(1 * 1024 * 1024))
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(headWithLength(40 * 1024 * 1024))
+      .mockResolvedValueOnce({ ok: true });
+
+    const text =
+      'Two assets:\nhttps://cdn.example.com/small.jpg\nhttps://cdn.example.com/huge.mp4\nEnjoy.';
+    await handleEngineCallback(baseCallback(text), mockEnv);
+
+    const posts = metaPosts(fetchMock);
+    expect(posts).toHaveLength(2);
+    expect(posts[0].type).toBe('image');
+    expect((posts[0].image as Record<string, unknown>).caption).toBe('Two assets:\n\nEnjoy.');
+    expect(posts[1].type).toBe('text');
+    expect((posts[1].text as Record<string, unknown>).body).toBe(
+      'https://cdn.example.com/huge.mp4'
+    );
+  });
+
+  it('proceeds with inline media send when HEAD returns no Content-Length (unknown)', async () => {
+    // Lenient: when we can't determine size, we let the send try.
+    fetchMock.mockResolvedValueOnce(HEAD_UNKNOWN).mockResolvedValueOnce({ ok: true });
+
+    const text = 'Mystery sized image:\nhttps://cdn.example.com/pic.jpg\nlooks fine.';
+    await handleEngineCallback(baseCallback(text), mockEnv);
+
+    const posts = metaPosts(fetchMock);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].type).toBe('image');
   });
 });


### PR DESCRIPTION
## Summary

- Meta's WhatsApp Cloud API returns **200** to `type:"video"` / `type:"image"` link sends even when the source file is over its per-link cap (5 MB image, 16 MB video) and then silently fails to deliver. The user sees nothing while logs say "Sent video message to user".
- Caught in staging on FIA Bible-video URLs (19–49 MB each, all over the cap). The 1.3.0 inline-media path emitted 4 video sends, all 200 from Meta, none of which actually rendered for the user.
- Fix: HEAD-fetch each media URL and skip the inline send when `Content-Length` is over the cap. The 1.3.0 fallback paths already handle "this attachment can't go inline" cleanly — first too-large attachment in caption mode falls back to sending the original text (URL inline as a clickable link); later too-large attachments fall back to a plain URL text message.
- Lenient on missing or unparseable `Content-Length` so we don't reject sends Meta would have accepted.
- Bumps version to 1.3.1.

## Test plan

- [x] `pnpm format:check` — clean.
- [x] `pnpm lint` — clean (0 errors, 3 pre-existing warnings).
- [x] `pnpm check` — clean.
- [x] `pnpm test` — 129/129 pass (3 new precheck cases: too-large first attachment, too-large later attachment, unknown size lenience; existing tests updated for the HEAD-then-POST sequence).
- [ ] Staging: re-run "pick a random one from fia" → expect to see prose with the four mp4 URLs as clickable links instead of nothing. (Inline rendering still won't work for these specific videos because the source files are too large — that's an FIA / worker-side concern.)
- [ ] Staging regression: an aquifer image under 5 MB → still renders inline as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)