### PR TITLE
(Claude) Unwrap markdown media links before extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-whatsapp-gateway",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/services/media-extractor.ts
+++ b/src/services/media-extractor.ts
@@ -34,6 +34,22 @@ const MEDIA_REGEX =
   // eslint-disable-next-line security/detect-unsafe-regex
   /https:\/\/[^\s<>"')]+?\.(jpg|jpeg|png|webp|gif|mp4|mov|3gp)(?:\?[^\s<>"')]*)?(?:#[^\s<>"')]*)?(?=$|[\s)\]}>"',;!?]|\.(?:\s|$))/gi;
 
+/**
+ * Markdown-wrapped media link: `![alt](url)` or `[label](url)` where the URL
+ * has a recognized media extension. Non-media links like `[docs](https://...)`
+ * are intentionally not matched here.
+ */
+const MEDIA_MARKDOWN_REGEX =
+  // eslint-disable-next-line security/detect-unsafe-regex
+  /!?\[([^\]]*)\]\((https:\/\/[^\s)]+?\.(?:jpg|jpeg|png|webp|gif|mp4|mov|3gp)(?:\?[^\s)]*)?(?:#[^\s)]*)?)\)/gi;
+
+function unwrapMediaMarkdown(text: string): string {
+  return text.replace(MEDIA_MARKDOWN_REGEX, (_match, label: string, url: string) => {
+    const trimmed = label.trim();
+    return trimmed ? `${trimmed} ${url}` : url;
+  });
+}
+
 function kindFor(ext: string): MediaKind | null {
   const lower = ext.toLowerCase();
   if (IMAGE_EXTS.has(lower)) return 'image';
@@ -70,11 +86,12 @@ function collapseWhitespace(text: string): string {
 }
 
 export function extractMedia(text: string): ExtractionResult {
-  const attachments = findAttachments(text);
+  const unwrapped = unwrapMediaMarkdown(text);
+  const attachments = findAttachments(unwrapped);
   if (attachments.length === 0) {
-    return { attachments: [], captionText: text };
+    return { attachments: [], captionText: unwrapped };
   }
   const urls = attachments.map((a) => a.url);
-  const captionText = collapseWhitespace(stripUrls(text, urls));
+  const captionText = collapseWhitespace(stripUrls(unwrapped, urls));
   return { attachments, captionText };
 }

--- a/tests/unit/handle-callback-media.test.ts
+++ b/tests/unit/handle-callback-media.test.ts
@@ -171,6 +171,26 @@ describe('handleEngineCallback with inline media', () => {
     expect((body.text as Record<string, unknown>).body).toBe(text);
   });
 
+  it('handles worker markdown-wrapped video link without leaking ![..]() shell into caption', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true });
+
+    const text = 'Here is:\n[FIA Fishing Net](https://cdn.example.com/vid.mp4)\nEnjoy!';
+    await handleEngineCallback(baseCallback(text), mockEnv);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = lastCallBody(fetchMock, 0);
+    expect(body.type).toBe('video');
+    const video = body.video as Record<string, unknown>;
+    expect(video.link).toBe('https://cdn.example.com/vid.mp4');
+    const caption = video.caption as string;
+    expect(caption).toContain('Here is:');
+    expect(caption).toContain('FIA Fishing Net');
+    expect(caption).toContain('Enjoy!');
+    expect(caption).not.toContain('[');
+    expect(caption).not.toContain('](');
+    expect(caption).not.toContain('https://');
+  });
+
   it('does not attempt media extraction when audio delivery succeeds', async () => {
     // 1: Meta audio upload ok, 2: send audio by id ok — no media/text call expected
     fetchMock

--- a/tests/unit/media-extractor.test.ts
+++ b/tests/unit/media-extractor.test.ts
@@ -120,11 +120,10 @@ describe('extractMedia', () => {
   });
 
   it('unwraps `![alt](url.jpg)` markdown image into one attachment with clean caption', () => {
-    const text = "Here's the map:\n![Mount Tabor Map](https://cdn.example.com/map.jpg)\nClick for details.";
+    const text =
+      "Here's the map:\n![Mount Tabor Map](https://cdn.example.com/map.jpg)\nClick for details.";
     const result = extractMedia(text);
-    expect(result.attachments).toEqual([
-      { kind: 'image', url: 'https://cdn.example.com/map.jpg' },
-    ]);
+    expect(result.attachments).toEqual([{ kind: 'image', url: 'https://cdn.example.com/map.jpg' }]);
     expect(result.captionText).toContain('Mount Tabor Map');
     expect(result.captionText).not.toContain('![');
     expect(result.captionText).not.toContain('](');
@@ -134,9 +133,7 @@ describe('extractMedia', () => {
   it('unwraps `[label](url.mp4)` markdown video link into one attachment with clean caption', () => {
     const text = 'Watch this:\n[Fishing Net](https://cdn.example.com/vid.mp4)\nEnjoy!';
     const result = extractMedia(text);
-    expect(result.attachments).toEqual([
-      { kind: 'video', url: 'https://cdn.example.com/vid.mp4' },
-    ]);
+    expect(result.attachments).toEqual([{ kind: 'video', url: 'https://cdn.example.com/vid.mp4' }]);
     expect(result.captionText).toContain('Fishing Net');
     expect(result.captionText).not.toContain('[');
     expect(result.captionText).not.toContain('](');
@@ -164,9 +161,7 @@ describe('extractMedia', () => {
   it('classifies by URL extension even when prefix mismatches (`![alt](vid.mp4)` is video)', () => {
     const text = '![odd](https://cdn.example.com/vid.mp4)';
     const result = extractMedia(text);
-    expect(result.attachments).toEqual([
-      { kind: 'video', url: 'https://cdn.example.com/vid.mp4' },
-    ]);
+    expect(result.attachments).toEqual([{ kind: 'video', url: 'https://cdn.example.com/vid.mp4' }]);
   });
 
   it('extracts both a markdown-wrapped media link and a bare URL in order', () => {

--- a/tests/unit/media-extractor.test.ts
+++ b/tests/unit/media-extractor.test.ts
@@ -118,4 +118,70 @@ describe('extractMedia', () => {
     const result = extractMedia(text);
     expect(result.attachments.map((a) => a.kind)).toEqual(['video', 'video']);
   });
+
+  it('unwraps `![alt](url.jpg)` markdown image into one attachment with clean caption', () => {
+    const text = "Here's the map:\n![Mount Tabor Map](https://cdn.example.com/map.jpg)\nClick for details.";
+    const result = extractMedia(text);
+    expect(result.attachments).toEqual([
+      { kind: 'image', url: 'https://cdn.example.com/map.jpg' },
+    ]);
+    expect(result.captionText).toContain('Mount Tabor Map');
+    expect(result.captionText).not.toContain('![');
+    expect(result.captionText).not.toContain('](');
+    expect(result.captionText).not.toContain('https://');
+  });
+
+  it('unwraps `[label](url.mp4)` markdown video link into one attachment with clean caption', () => {
+    const text = 'Watch this:\n[Fishing Net](https://cdn.example.com/vid.mp4)\nEnjoy!';
+    const result = extractMedia(text);
+    expect(result.attachments).toEqual([
+      { kind: 'video', url: 'https://cdn.example.com/vid.mp4' },
+    ]);
+    expect(result.captionText).toContain('Fishing Net');
+    expect(result.captionText).not.toContain('[');
+    expect(result.captionText).not.toContain('](');
+    expect(result.captionText).not.toContain('https://');
+  });
+
+  it('unwraps `![](url.jpg)` with empty alt to just the URL — caption has no stray brackets or whitespace', () => {
+    const text = 'Before\n![](https://cdn.example.com/bare.jpg)\nAfter';
+    const result = extractMedia(text);
+    expect(result.attachments).toEqual([
+      { kind: 'image', url: 'https://cdn.example.com/bare.jpg' },
+    ]);
+    expect(result.captionText).toBe('Before\n\nAfter');
+    expect(result.captionText).not.toContain('[');
+    expect(result.captionText).not.toContain(']');
+  });
+
+  it('leaves non-media markdown links untouched in the caption', () => {
+    const text = 'See [docs](https://example.com/policy) for details.';
+    const result = extractMedia(text);
+    expect(result.attachments).toEqual([]);
+    expect(result.captionText).toBe(text);
+  });
+
+  it('classifies by URL extension even when prefix mismatches (`![alt](vid.mp4)` is video)', () => {
+    const text = '![odd](https://cdn.example.com/vid.mp4)';
+    const result = extractMedia(text);
+    expect(result.attachments).toEqual([
+      { kind: 'video', url: 'https://cdn.example.com/vid.mp4' },
+    ]);
+  });
+
+  it('extracts both a markdown-wrapped media link and a bare URL in order', () => {
+    const text =
+      'First ![Map](https://cdn.example.com/a.jpg) then bare https://cdn.example.com/b.mp4 done.';
+    const result = extractMedia(text);
+    expect(result.attachments).toEqual([
+      { kind: 'image', url: 'https://cdn.example.com/a.jpg' },
+      { kind: 'video', url: 'https://cdn.example.com/b.mp4' },
+    ]);
+    expect(result.captionText).toContain('Map');
+    expect(result.captionText).toContain('First');
+    expect(result.captionText).toContain('done.');
+    expect(result.captionText).not.toContain('![');
+    expect(result.captionText).not.toContain('](');
+    expect(result.captionText).not.toContain('https://');
+  });
 });


### PR DESCRIPTION
## Summary

- Add `unwrapMediaMarkdown` pre-pass to `extractMedia()` so the upcoming worker prompt change — which forces `![alt](url)` for images and `[label](url)` for videos — does not leave `![..]()` shells in WhatsApp captions.
- Non-media markdown links (e.g. `[docs](https://example.com/policy)`) are left untouched. Bare URLs continue to work — fully backward compatible.
- Bumps version `1.3.0` → `1.3.1`.

## Test plan

- [x] `pnpm lint` — clean (3 pre-existing warnings, 0 errors)
- [x] `pnpm check` — clean
- [x] `pnpm test` — 133 tests pass (all prior tests + 6 new media-extractor cases + 1 new end-to-end callback case)
- [ ] Staging: send a worker response containing `![Map](https://small-image.jpg)` → caption reads `Map`, no markdown artifacts
- [ ] Staging: send a response containing `[docs](https://example.com/x)` → caption still shows `[docs](https://example.com/x)` literally (WhatsApp auto-linkifies the URL portion)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)