### PR TITLE
(Claude) Drop alt text in unwrapMediaMarkdown to avoid label echo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-whatsapp-gateway",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/services/media-extractor.ts
+++ b/src/services/media-extractor.ts
@@ -44,10 +44,7 @@ const MEDIA_MARKDOWN_REGEX =
   /!?\[([^\]]*)\]\((https:\/\/[^\s)]+?\.(?:jpg|jpeg|png|webp|gif|mp4|mov|3gp)(?:\?[^\s)]*)?(?:#[^\s)]*)?)\)/gi;
 
 function unwrapMediaMarkdown(text: string): string {
-  return text.replace(MEDIA_MARKDOWN_REGEX, (_match, label: string, url: string) => {
-    const trimmed = label.trim();
-    return trimmed ? `${trimmed} ${url}` : url;
-  });
+  return text.replace(MEDIA_MARKDOWN_REGEX, (_match, _label: string, url: string) => url);
 }
 
 function kindFor(ext: string): MediaKind | null {

--- a/tests/unit/handle-callback-media.test.ts
+++ b/tests/unit/handle-callback-media.test.ts
@@ -171,7 +171,7 @@ describe('handleEngineCallback with inline media', () => {
     expect((body.text as Record<string, unknown>).body).toBe(text);
   });
 
-  it('handles worker markdown-wrapped video link without leaking ![..]() shell into caption', async () => {
+  it('handles worker markdown-wrapped video link without leaking ![..]() shell or label echo into caption', async () => {
     fetchMock.mockResolvedValueOnce({ ok: true });
 
     const text = 'Here is:\n[FIA Fishing Net](https://cdn.example.com/vid.mp4)\nEnjoy!';
@@ -183,9 +183,8 @@ describe('handleEngineCallback with inline media', () => {
     const video = body.video as Record<string, unknown>;
     expect(video.link).toBe('https://cdn.example.com/vid.mp4');
     const caption = video.caption as string;
-    expect(caption).toContain('Here is:');
-    expect(caption).toContain('FIA Fishing Net');
-    expect(caption).toContain('Enjoy!');
+    expect(caption).toBe('Here is:\n\nEnjoy!');
+    expect(caption).not.toContain('FIA Fishing Net');
     expect(caption).not.toContain('[');
     expect(caption).not.toContain('](');
     expect(caption).not.toContain('https://');

--- a/tests/unit/media-extractor.test.ts
+++ b/tests/unit/media-extractor.test.ts
@@ -119,25 +119,37 @@ describe('extractMedia', () => {
     expect(result.attachments.map((a) => a.kind)).toEqual(['video', 'video']);
   });
 
-  it('unwraps `![alt](url.jpg)` markdown image into one attachment with clean caption', () => {
+  it('unwraps `![alt](url.jpg)` markdown image into one attachment, dropping alt text from caption', () => {
     const text =
       "Here's the map:\n![Mount Tabor Map](https://cdn.example.com/map.jpg)\nClick for details.";
     const result = extractMedia(text);
     expect(result.attachments).toEqual([{ kind: 'image', url: 'https://cdn.example.com/map.jpg' }]);
-    expect(result.captionText).toContain('Mount Tabor Map');
+    expect(result.captionText).toBe("Here's the map:\n\nClick for details.");
+    expect(result.captionText).not.toContain('Mount Tabor Map');
     expect(result.captionText).not.toContain('![');
     expect(result.captionText).not.toContain('](');
     expect(result.captionText).not.toContain('https://');
   });
 
-  it('unwraps `[label](url.mp4)` markdown video link into one attachment with clean caption', () => {
+  it('unwraps `[label](url.mp4)` markdown video link into one attachment, dropping label from caption', () => {
     const text = 'Watch this:\n[Fishing Net](https://cdn.example.com/vid.mp4)\nEnjoy!';
     const result = extractMedia(text);
     expect(result.attachments).toEqual([{ kind: 'video', url: 'https://cdn.example.com/vid.mp4' }]);
-    expect(result.captionText).toContain('Fishing Net');
+    expect(result.captionText).toBe('Watch this:\n\nEnjoy!');
+    expect(result.captionText).not.toContain('Fishing Net');
     expect(result.captionText).not.toContain('[');
     expect(result.captionText).not.toContain('](');
     expect(result.captionText).not.toContain('https://');
+  });
+
+  it('does not double the label when worker pre-labels image in prose', () => {
+    const text = 'Bread:\n![Bread](https://cdn.example.com/bread.jpg)\n\nMore prose.';
+    const result = extractMedia(text);
+    expect(result.attachments).toEqual([
+      { kind: 'image', url: 'https://cdn.example.com/bread.jpg' },
+    ]);
+    expect(result.captionText).toBe('Bread:\n\nMore prose.');
+    expect(result.captionText).not.toMatch(/Bread\s+Bread/);
   });
 
   it('unwraps `![](url.jpg)` with empty alt to just the URL — caption has no stray brackets or whitespace', () => {
@@ -164,7 +176,7 @@ describe('extractMedia', () => {
     expect(result.attachments).toEqual([{ kind: 'video', url: 'https://cdn.example.com/vid.mp4' }]);
   });
 
-  it('extracts both a markdown-wrapped media link and a bare URL in order', () => {
+  it('extracts both a markdown-wrapped media link and a bare URL in order, dropping alt from caption', () => {
     const text =
       'First ![Map](https://cdn.example.com/a.jpg) then bare https://cdn.example.com/b.mp4 done.';
     const result = extractMedia(text);
@@ -172,9 +184,9 @@ describe('extractMedia', () => {
       { kind: 'image', url: 'https://cdn.example.com/a.jpg' },
       { kind: 'video', url: 'https://cdn.example.com/b.mp4' },
     ]);
-    expect(result.captionText).toContain('Map');
     expect(result.captionText).toContain('First');
     expect(result.captionText).toContain('done.');
+    expect(result.captionText).not.toContain('Map');
     expect(result.captionText).not.toContain('![');
     expect(result.captionText).not.toContain('](');
     expect(result.captionText).not.toContain('https://');


### PR DESCRIPTION
## Summary

- `unwrapMediaMarkdown` now substitutes just the URL (drops the `![alt]` / `[label]` text). Eliminates the visible doubling bug when the worker emits `Bread:\n![Bread](url)` — caption was `Bread:\nBread`, now `Bread:`.
- Trade-off accepted: a bare `![alt](url)` response now ships with an empty caption instead of alt-as-caption. Acceptable because the upstream worker prompt fix (unfoldingWord/bt-servant-worker#166) will emit one image per response with surrounding prose context that becomes the caption naturally.
- Independent of #166 — can ship in either order. Belt-and-suspenders insurance against the worker prompt rule slipping in the future.
- Bumps version `1.3.1` → `1.3.2`.

## Test plan

- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — clean (3 pre-existing warnings, 0 errors)
- [x] `pnpm check` — clean
- [x] `pnpm test` — 134 tests pass (was 133, +1 regression test `does not double the label when worker pre-labels image in prose`)
- [ ] Staging: trigger a multi-image worker response in current style → captions show no doubled labels
- [ ] Staging: trigger a single-image response with `Label:\n![Label](url)` → caption reads `Label:`, image attached
- [ ] Staging: existing single-image bare-URL flows continue to work unchanged

Closes #26

Related: #25 (added unwrap), unfoldingWord/bt-servant-worker#166 (upstream prompt fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)