### PR TITLE
(Claude) Make media extraction markdown-intent based (#28)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-whatsapp-gateway",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/services/media-extractor.ts
+++ b/src/services/media-extractor.ts
@@ -14,7 +14,7 @@ export interface MediaAttachment {
 
 export interface ExtractionResult {
   attachments: MediaAttachment[];
-  /** Original text with matched URLs removed and whitespace collapsed. Not truncated. */
+  /** Original text with media markdown unwrapped and whitespace collapsed. URLs are preserved. */
   captionText: string;
 }
 
@@ -25,19 +25,13 @@ const IMAGE_EXTS = new Set(['jpg', 'jpeg', 'png', 'webp', 'gif']);
 const VIDEO_EXTS = new Set(['mp4', 'mov', '3gp']);
 
 /**
- * HTTPS URL ending in a recognized media extension, with optional query/fragment.
- * The trailing lookahead ensures the extension terminates the URL — so
- * `.jpg/foo` does not match but `.jpg`, `.jpg?v=1`, `.jpg.` (sentence-final)
- * and `.jpg)` (in prose) all do.
- */
-const MEDIA_REGEX =
-  // eslint-disable-next-line security/detect-unsafe-regex
-  /https:\/\/[^\s<>"')]+?\.(jpg|jpeg|png|webp|gif|mp4|mov|3gp)(?:\?[^\s<>"')]*)?(?:#[^\s<>"')]*)?(?=$|[\s)\]}>"',;!?]|\.(?:\s|$))/gi;
-
-/**
  * Markdown-wrapped media link: `![alt](url)` or `[label](url)` where the URL
  * has a recognized media extension. Non-media links like `[docs](https://...)`
  * are intentionally not matched here.
+ *
+ * Wrapper presence is treated as explicit attach-intent. Bare URLs in the
+ * surrounding text are not extracted as attachments — they pass through to
+ * the caption as the silent-drop fallback if Meta drops the attachment.
  */
 const MEDIA_MARKDOWN_REGEX =
   // eslint-disable-next-line security/detect-unsafe-regex
@@ -45,6 +39,12 @@ const MEDIA_MARKDOWN_REGEX =
 
 function unwrapMediaMarkdown(text: string): string {
   return text.replace(MEDIA_MARKDOWN_REGEX, (_match, _label: string, url: string) => url);
+}
+
+function extensionOf(url: string): string | null {
+  const m = url.match(/\.([a-z0-9]+)(?:\?[^#]*)?(?:#.*)?$/i);
+  const ext = m?.[1];
+  return ext ? ext.toLowerCase() : null;
 }
 
 function kindFor(ext: string): MediaKind | null {
@@ -55,23 +55,18 @@ function kindFor(ext: string): MediaKind | null {
 }
 
 function findAttachments(text: string): MediaAttachment[] {
-  const attachments: MediaAttachment[] = [];
-  for (const match of text.matchAll(MEDIA_REGEX)) {
-    const ext = match[1];
+  const out: MediaAttachment[] = [];
+  const seen = new Set<string>();
+  for (const match of text.matchAll(MEDIA_MARKDOWN_REGEX)) {
+    const url = match[2];
+    if (!url || seen.has(url)) continue;
+    seen.add(url);
+    const ext = extensionOf(url);
     if (!ext) continue;
     const kind = kindFor(ext);
-    if (!kind) continue;
-    attachments.push({ kind, url: match[0] });
+    if (kind) out.push({ kind, url });
   }
-  return attachments;
-}
-
-function stripUrls(text: string, urls: string[]): string {
-  let result = text;
-  for (const url of urls) {
-    result = result.split(url).join('');
-  }
-  return result;
+  return out;
 }
 
 function collapseWhitespace(text: string): string {
@@ -83,12 +78,8 @@ function collapseWhitespace(text: string): string {
 }
 
 export function extractMedia(text: string): ExtractionResult {
+  const attachments = findAttachments(text);
   const unwrapped = unwrapMediaMarkdown(text);
-  const attachments = findAttachments(unwrapped);
-  if (attachments.length === 0) {
-    return { attachments: [], captionText: unwrapped };
-  }
-  const urls = attachments.map((a) => a.url);
-  const captionText = collapseWhitespace(stripUrls(unwrapped, urls));
+  const captionText = collapseWhitespace(unwrapped);
   return { attachments, captionText };
 }

--- a/src/services/media-extractor.ts
+++ b/src/services/media-extractor.ts
@@ -37,8 +37,23 @@ const MEDIA_MARKDOWN_REGEX =
   // eslint-disable-next-line security/detect-unsafe-regex
   /!?\[([^\]]*)\]\((https:\/\/[^\s)]+?\.(?:jpg|jpeg|png|webp|gif|mp4|mov|3gp)(?:\?[^\s)]*)?(?:#[^\s)]*)?)\)/gi;
 
+/**
+ * Aquifer-style linked thumbnail: `[![alt](thumb-url)](outer-url)`. The inner
+ * `]` would defeat `MEDIA_MARKDOWN_REGEX`'s `[^\]]*` label so we match the
+ * full nested pattern explicitly to keep the outer media URL attachable.
+ * Both URLs must have recognized media extensions.
+ */
+const LINKED_THUMB_REGEX =
+  // eslint-disable-next-line security/detect-unsafe-regex
+  /\[!?\[([^\]]*)\]\((https:\/\/[^\s)]+?\.(?:jpg|jpeg|png|webp|gif|mp4|mov|3gp)(?:\?[^\s)]*)?(?:#[^\s)]*)?)\)\]\((https:\/\/[^\s)]+?\.(?:jpg|jpeg|png|webp|gif|mp4|mov|3gp)(?:\?[^\s)]*)?(?:#[^\s)]*)?)\)/gi;
+
 function unwrapMediaMarkdown(text: string): string {
-  return text.replace(MEDIA_MARKDOWN_REGEX, (_match, _label: string, url: string) => url);
+  return text
+    .replace(
+      LINKED_THUMB_REGEX,
+      (_match, _label: string, thumbUrl: string, outerUrl: string) => `${thumbUrl} ${outerUrl}`
+    )
+    .replace(MEDIA_MARKDOWN_REGEX, (_match, _label: string, url: string) => url);
 }
 
 function extensionOf(url: string): string | null {
@@ -57,14 +72,20 @@ function kindFor(ext: string): MediaKind | null {
 function findAttachments(text: string): MediaAttachment[] {
   const out: MediaAttachment[] = [];
   const seen = new Set<string>();
-  for (const match of text.matchAll(MEDIA_MARKDOWN_REGEX)) {
-    const url = match[2];
-    if (!url || seen.has(url)) continue;
+  const add = (url: string | undefined): void => {
+    if (!url || seen.has(url)) return;
     seen.add(url);
     const ext = extensionOf(url);
-    if (!ext) continue;
+    if (!ext) return;
     const kind = kindFor(ext);
     if (kind) out.push({ kind, url });
+  };
+  for (const match of text.matchAll(LINKED_THUMB_REGEX)) {
+    add(match[2]);
+    add(match[3]);
+  }
+  for (const match of text.matchAll(MEDIA_MARKDOWN_REGEX)) {
+    add(match[2]);
   }
   return out;
 }

--- a/src/services/message-handler.ts
+++ b/src/services/message-handler.ts
@@ -377,9 +377,10 @@ async function sendRemainingAttachments(
       kind: attachment.kind,
       url: redactUrl(attachment.url),
     });
-    // The URL was stripped from the caption/text path, so if the media send
-    // fails the asset would disappear entirely. Send the URL as plain text
-    // so the user still has a clickable link.
+    // Belt-and-suspenders: the URL is also preserved in the caption/text
+    // path now, but in long-text mode the caption is sent as a separate
+    // message — re-sending the URL keeps the link adjacent to the failed
+    // media slot.
     await sendToWhatsApp(userId, attachment.url, env);
   }
 }

--- a/tests/unit/handle-callback-media.test.ts
+++ b/tests/unit/handle-callback-media.test.ts
@@ -50,8 +50,7 @@ describe('handleEngineCallback with inline media', () => {
   it('sends image message with caption (URL preserved as fallback) when text wraps one jpg URL', async () => {
     fetchMock.mockResolvedValueOnce({ ok: true });
 
-    const text =
-      'Check this out:\n![Pic](https://cdn.example.com/pic.jpg)\n\nIsn’t it beautiful?';
+    const text = 'Check this out:\n![Pic](https://cdn.example.com/pic.jpg)\n\nIsn’t it beautiful?';
     await handleEngineCallback(baseCallback(text), mockEnv);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);

--- a/tests/unit/handle-callback-media.test.ts
+++ b/tests/unit/handle-callback-media.test.ts
@@ -47,10 +47,11 @@ describe('handleEngineCallback with inline media', () => {
     globalThis.fetch = originalFetch;
   });
 
-  it('sends image message with stripped caption when text has one jpg URL', async () => {
+  it('sends image message with caption (URL preserved as fallback) when text wraps one jpg URL', async () => {
     fetchMock.mockResolvedValueOnce({ ok: true });
 
-    const text = 'Check this out:\nhttps://cdn.example.com/pic.jpg\n\nIsn’t it beautiful?';
+    const text =
+      'Check this out:\n![Pic](https://cdn.example.com/pic.jpg)\n\nIsn’t it beautiful?';
     await handleEngineCallback(baseCallback(text), mockEnv);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -58,14 +59,14 @@ describe('handleEngineCallback with inline media', () => {
     expect(body.type).toBe('image');
     expect(body.image).toEqual({
       link: 'https://cdn.example.com/pic.jpg',
-      caption: 'Check this out:\n\nIsn’t it beautiful?',
+      caption: 'Check this out:\nhttps://cdn.example.com/pic.jpg\n\nIsn’t it beautiful?',
     });
   });
 
-  it('sends video message with stripped caption when text has one mp4 URL', async () => {
+  it('sends video message with caption (URL preserved as fallback) when text wraps one mp4 URL', async () => {
     fetchMock.mockResolvedValueOnce({ ok: true });
 
-    const text = 'Here is a video:\nhttps://cdn.example.com/clip.mp4\n\nEnjoy!';
+    const text = 'Here is a video:\n[Watch](https://cdn.example.com/clip.mp4)\n\nEnjoy!';
     await handleEngineCallback(baseCallback(text), mockEnv);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -73,21 +74,24 @@ describe('handleEngineCallback with inline media', () => {
     expect(body.type).toBe('video');
     expect(body.video).toEqual({
       link: 'https://cdn.example.com/clip.mp4',
-      caption: 'Here is a video:\n\nEnjoy!',
+      caption: 'Here is a video:\nhttps://cdn.example.com/clip.mp4\n\nEnjoy!',
     });
   });
 
-  it('sends two media messages with caption on first only when text has two URLs', async () => {
+  it('sends two media messages with caption on first only when text wraps two URLs', async () => {
     fetchMock.mockResolvedValueOnce({ ok: true }).mockResolvedValueOnce({ ok: true });
 
-    const text = 'Two things:\nhttps://cdn.example.com/a.jpg\nhttps://cdn.example.com/b.mp4\nDone.';
+    const text =
+      'Two things:\n![A](https://cdn.example.com/a.jpg)\n[B](https://cdn.example.com/b.mp4)\nDone.';
     await handleEngineCallback(baseCallback(text), mockEnv);
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
     const first = lastCallBody(fetchMock, 0);
     expect(first.type).toBe('image');
-    expect((first.image as Record<string, unknown>).caption).toBe('Two things:\n\nDone.');
+    expect((first.image as Record<string, unknown>).caption).toBe(
+      'Two things:\nhttps://cdn.example.com/a.jpg\nhttps://cdn.example.com/b.mp4\nDone.'
+    );
 
     const second = lastCallBody(fetchMock, 1);
     expect(second.type).toBe('video');
@@ -99,7 +103,7 @@ describe('handleEngineCallback with inline media', () => {
       .mockResolvedValueOnce({ ok: false, status: 400, text: async () => 'Bad Request' })
       .mockResolvedValueOnce({ ok: true });
 
-    const text = 'Look:\nhttps://cdn.example.com/broken.jpg\nMoving on.';
+    const text = 'Look:\n![Img](https://cdn.example.com/broken.jpg)\nMoving on.';
     await handleEngineCallback(baseCallback(text), mockEnv);
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -109,40 +113,43 @@ describe('handleEngineCallback with inline media', () => {
   });
 
   it('sends the URL as text when a later media fails, so the asset is not lost', async () => {
-    // First succeeds with caption. Second fails — user already has the caption,
-    // but the failed URL was stripped from the caption so we send just the URL
-    // as plain text to preserve the clickable link.
+    // First media succeeds with caption (which already contains both URLs as
+    // silent-drop fallback). Second media fails — we still send its URL as
+    // plain text. Redundant with the caption today, but cheap insurance for
+    // long-text mode where captions are not on the media itself.
     fetchMock
       .mockResolvedValueOnce({ ok: true })
       .mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'Server Error' })
       .mockResolvedValueOnce({ ok: true });
 
-    const text = 'Two things:\nhttps://cdn.example.com/a.jpg\nhttps://cdn.example.com/b.mp4\nDone.';
+    const text =
+      'Two things:\n![A](https://cdn.example.com/a.jpg)\n[B](https://cdn.example.com/b.mp4)\nDone.';
     await handleEngineCallback(baseCallback(text), mockEnv);
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
 
-    // First: image with caption.
+    // First: image with caption (both URLs preserved in caption).
     const first = lastCallBody(fetchMock, 0);
     expect(first.type).toBe('image');
-    expect((first.image as Record<string, unknown>).caption).toBe('Two things:\n\nDone.');
+    expect((first.image as Record<string, unknown>).caption).toBe(
+      'Two things:\nhttps://cdn.example.com/a.jpg\nhttps://cdn.example.com/b.mp4\nDone.'
+    );
 
     // Second: failed video attempt.
     const second = lastCallBody(fetchMock, 1);
     expect(second.type).toBe('video');
 
-    // Third: the URL of the failed media, sent as plain text — NOT the full
-    // original text (which would duplicate the caption).
+    // Third: the URL of the failed media, sent as plain text.
     const third = lastCallBody(fetchMock, 2);
     expect(third.type).toBe('text');
     expect((third.text as Record<string, unknown>).body).toBe('https://cdn.example.com/b.mp4');
   });
 
-  it('sends media captionless and full text separately when stripped text exceeds 1024 chars', async () => {
+  it('sends media captionless and full text (URL included) separately when caption exceeds 1024 chars', async () => {
     fetchMock.mockResolvedValueOnce({ ok: true }).mockResolvedValueOnce({ ok: true });
 
     const filler = 'a'.repeat(1100);
-    const text = `${filler}\n\nhttps://cdn.example.com/pic.jpg\n\ntrailing`;
+    const text = `${filler}\n\n![Pic](https://cdn.example.com/pic.jpg)\n\ntrailing`;
     await handleEngineCallback(baseCallback(text), mockEnv);
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -156,7 +163,7 @@ describe('handleEngineCallback with inline media', () => {
     const body = (textCall.text as Record<string, unknown>).body as string;
     expect(body).toContain(filler);
     expect(body).toContain('trailing');
-    expect(body).not.toContain('https://cdn.example.com/pic.jpg');
+    expect(body).toContain('https://cdn.example.com/pic.jpg');
   });
 
   it('uses existing text path when no media URLs are present', async () => {
@@ -171,7 +178,7 @@ describe('handleEngineCallback with inline media', () => {
     expect((body.text as Record<string, unknown>).body).toBe(text);
   });
 
-  it('handles worker markdown-wrapped video link without leaking ![..]() shell or label echo into caption', async () => {
+  it('handles worker markdown-wrapped video link: drops the label echo but keeps the URL as fallback', async () => {
     fetchMock.mockResolvedValueOnce({ ok: true });
 
     const text = 'Here is:\n[FIA Fishing Net](https://cdn.example.com/vid.mp4)\nEnjoy!';
@@ -183,11 +190,10 @@ describe('handleEngineCallback with inline media', () => {
     const video = body.video as Record<string, unknown>;
     expect(video.link).toBe('https://cdn.example.com/vid.mp4');
     const caption = video.caption as string;
-    expect(caption).toBe('Here is:\n\nEnjoy!');
+    expect(caption).toBe('Here is:\nhttps://cdn.example.com/vid.mp4\nEnjoy!');
     expect(caption).not.toContain('FIA Fishing Net');
     expect(caption).not.toContain('[');
     expect(caption).not.toContain('](');
-    expect(caption).not.toContain('https://');
   });
 
   it('does not attempt media extraction when audio delivery succeeds', async () => {

--- a/tests/unit/media-extractor.test.ts
+++ b/tests/unit/media-extractor.test.ts
@@ -80,9 +80,7 @@ describe('extractMedia', () => {
   it('collapses extra blank lines around an unwrapped wrapper', () => {
     const text = 'Line 1\n\n\n![Img](https://cdn.example.com/img.jpg)\n\n\nLine 2';
     const result = extractMedia(text);
-    expect(result.captionText).toBe(
-      'Line 1\n\nhttps://cdn.example.com/img.jpg\n\nLine 2'
-    );
+    expect(result.captionText).toBe('Line 1\n\nhttps://cdn.example.com/img.jpg\n\nLine 2');
   });
 
   it('returns the full caption without truncation even when very long', () => {
@@ -125,9 +123,7 @@ describe('extractMedia', () => {
     const text = 'Watch this:\n[Fishing Net](https://cdn.example.com/vid.mp4)\nEnjoy!';
     const result = extractMedia(text);
     expect(result.attachments).toEqual([{ kind: 'video', url: 'https://cdn.example.com/vid.mp4' }]);
-    expect(result.captionText).toBe(
-      'Watch this:\nhttps://cdn.example.com/vid.mp4\nEnjoy!'
-    );
+    expect(result.captionText).toBe('Watch this:\nhttps://cdn.example.com/vid.mp4\nEnjoy!');
     expect(result.captionText).not.toContain('Fishing Net');
     expect(result.captionText).not.toContain('[');
     expect(result.captionText).not.toContain('](');
@@ -139,9 +135,7 @@ describe('extractMedia', () => {
     expect(result.attachments).toEqual([
       { kind: 'image', url: 'https://cdn.example.com/bread.jpg' },
     ]);
-    expect(result.captionText).toBe(
-      'Bread:\nhttps://cdn.example.com/bread.jpg\n\nMore prose.'
-    );
+    expect(result.captionText).toBe('Bread:\nhttps://cdn.example.com/bread.jpg\n\nMore prose.');
     expect(result.captionText).not.toMatch(/Bread\s+Bread/);
   });
 
@@ -183,9 +177,7 @@ describe('extractMedia', () => {
     const text =
       'First ![Map](https://cdn.example.com/a.jpg) then bare https://cdn.example.com/b.mp4 done.';
     const result = extractMedia(text);
-    expect(result.attachments).toEqual([
-      { kind: 'image', url: 'https://cdn.example.com/a.jpg' },
-    ]);
+    expect(result.attachments).toEqual([{ kind: 'image', url: 'https://cdn.example.com/a.jpg' }]);
     expect(result.captionText).toBe(
       'First https://cdn.example.com/a.jpg then bare https://cdn.example.com/b.mp4 done.'
     );
@@ -195,26 +187,21 @@ describe('extractMedia', () => {
     const text =
       '[Watch](https://cdn.example.com/v.mp4) and also [Open the video](https://cdn.example.com/v.mp4)';
     const result = extractMedia(text);
-    expect(result.attachments).toEqual([
-      { kind: 'video', url: 'https://cdn.example.com/v.mp4' },
-    ]);
+    expect(result.attachments).toEqual([{ kind: 'video', url: 'https://cdn.example.com/v.mp4' }]);
     const occurrences = result.captionText.match(/https:\/\/cdn\.example\.com\/v\.mp4/g);
     expect(occurrences).toHaveLength(2);
   });
 
-  it('Aquifer linked-thumbnail `[![Thumb](thumb.jpg)](v.mp4)`: inner image attaches, outer video URL still survives in caption', () => {
-    // Documented limitation: the outer link's "label" contains brackets so the
-    // wrapper regex (`[^\]]*`) does not match it. Only the inner image is
-    // extracted as an attachment. The outer URL is unaffected by unwrap and
-    // therefore still appears in caption text — the silent-drop fallback
-    // still works.
+  it('Aquifer linked-thumbnail `[![Thumb](thumb.jpg)](v.mp4)`: both inner image and outer video attach; both URLs in caption', () => {
     const text = '[![Thumb](https://cdn.example.com/thumb.jpg)](https://cdn.example.com/v.mp4)';
     const result = extractMedia(text);
     expect(result.attachments).toEqual([
       { kind: 'image', url: 'https://cdn.example.com/thumb.jpg' },
+      { kind: 'video', url: 'https://cdn.example.com/v.mp4' },
     ]);
-    expect(result.captionText).toContain('https://cdn.example.com/thumb.jpg');
-    expect(result.captionText).toContain('https://cdn.example.com/v.mp4');
+    expect(result.captionText).toBe(
+      'https://cdn.example.com/thumb.jpg https://cdn.example.com/v.mp4'
+    );
   });
 
   it('Mount Tabor end-to-end sample: 1 video + 2 images, all three URLs preserved in caption', () => {

--- a/tests/unit/media-extractor.test.ts
+++ b/tests/unit/media-extractor.test.ts
@@ -9,43 +9,44 @@ describe('extractMedia', () => {
     expect(result.captionText).toBe(text);
   });
 
-  it('extracts a single https jpg URL and strips it from the caption', () => {
+  it('extracts a wrapped jpg URL and preserves the URL in the caption as fallback', () => {
     const text =
-      "I've got the goods!\n\n🏛 *Acropolis Athens*\nhttps://cdn.example.com/acropolis.jpg\n\nRelevant to Paul's visit.";
+      "I've got the goods!\n\n🏛 *Acropolis Athens*\n![Acropolis](https://cdn.example.com/acropolis.jpg)\n\nRelevant to Paul's visit.";
     const result = extractMedia(text);
     expect(result.attachments).toEqual([
       { kind: 'image', url: 'https://cdn.example.com/acropolis.jpg' },
     ]);
     expect(result.captionText).toBe(
-      "I've got the goods!\n\n🏛 *Acropolis Athens*\n\nRelevant to Paul's visit."
+      "I've got the goods!\n\n🏛 *Acropolis Athens*\nhttps://cdn.example.com/acropolis.jpg\n\nRelevant to Paul's visit."
     );
-    expect(result.captionText).not.toContain('https://');
   });
 
-  it('extracts a single mp4 as a video attachment', () => {
-    const text = 'Watch:\nhttps://cdn.example.com/fishing.mp4\nCool!';
+  it('extracts a wrapped mp4 as a video attachment', () => {
+    const text = 'Watch:\n[Fishing](https://cdn.example.com/fishing.mp4)\nCool!';
     const result = extractMedia(text);
     expect(result.attachments).toEqual([
       { kind: 'video', url: 'https://cdn.example.com/fishing.mp4' },
     ]);
+    expect(result.captionText).toContain('https://cdn.example.com/fishing.mp4');
   });
 
-  it('captures query string and fragment as part of the URL', () => {
-    const text = 'See https://cdn.example.com/img.jpg?v=1&t=2#frag here.';
+  it('captures query string and fragment as part of the URL and preserves them in caption', () => {
+    const text = '![Img](https://cdn.example.com/img.jpg?v=1&t=2#frag)';
     const result = extractMedia(text);
     expect(result.attachments[0]?.url).toBe('https://cdn.example.com/img.jpg?v=1&t=2#frag');
+    expect(result.captionText).toBe('https://cdn.example.com/img.jpg?v=1&t=2#frag');
   });
 
-  it('skips http:// (non-HTTPS) URLs', () => {
-    const text = 'http://insecure.example.com/img.jpg is not safe.';
+  it('skips http:// (non-HTTPS) URLs even when wrapped', () => {
+    const text = '![X](http://insecure.example.com/img.jpg) is not safe.';
     const result = extractMedia(text);
     expect(result.attachments).toEqual([]);
     expect(result.captionText).toBe(text);
   });
 
-  it('extracts multiple URLs in the order they appear', () => {
+  it('extracts multiple wrapped URLs in the order they appear', () => {
     const text =
-      'First: https://cdn.example.com/a.jpg then https://cdn.example.com/b.mp4 and done.';
+      'First: ![A](https://cdn.example.com/a.jpg) then [B](https://cdn.example.com/b.mp4) and done.';
     const result = extractMedia(text);
     expect(result.attachments).toEqual([
       { kind: 'image', url: 'https://cdn.example.com/a.jpg' },
@@ -53,30 +54,15 @@ describe('extractMedia', () => {
     ]);
   });
 
-  it('does not include surrounding punctuation in the URL', () => {
-    const text = 'Check (https://cdn.example.com/img.jpg) or "https://cdn.example.com/vid.mp4".';
-    const result = extractMedia(text);
-    expect(result.attachments.map((a) => a.url)).toEqual([
-      'https://cdn.example.com/img.jpg',
-      'https://cdn.example.com/vid.mp4',
-    ]);
-  });
-
-  it('handles a terminal period (sentence-final URL)', () => {
-    const text = 'The image is at https://cdn.example.com/img.jpg.';
-    const result = extractMedia(text);
-    expect(result.attachments[0]?.url).toBe('https://cdn.example.com/img.jpg');
-    expect(result.captionText).toBe('The image is at .');
-  });
-
-  it('does not match when extension is mid-path (.jpg/foo)', () => {
-    const text = 'Not media: https://cdn.example.com/img.jpg/foo bar.';
+  it('does not extract media when extension is mid-path (.jpg/foo) inside a wrapper', () => {
+    const text = '![X](https://cdn.example.com/img.jpg/foo) bar.';
     const result = extractMedia(text);
     expect(result.attachments).toEqual([]);
   });
 
   it('matches case-insensitively for extensions', () => {
-    const text = 'Big file https://cdn.example.com/IMG.JPG and https://cdn.example.com/CLIP.MP4.';
+    const text =
+      'Big file ![A](https://cdn.example.com/IMG.JPG) and [B](https://cdn.example.com/CLIP.MP4).';
     const result = extractMedia(text);
     expect(result.attachments).toEqual([
       { kind: 'image', url: 'https://cdn.example.com/IMG.JPG' },
@@ -84,62 +70,67 @@ describe('extractMedia', () => {
     ]);
   });
 
-  it('produces an empty caption when the URL is the whole text', () => {
-    const text = 'https://cdn.example.com/img.jpg';
+  it('preserves the URL as the entire caption when the wrapped URL is the whole text', () => {
+    const text = '![](https://cdn.example.com/bare.jpg)';
     const result = extractMedia(text);
     expect(result.attachments).toHaveLength(1);
-    expect(result.captionText).toBe('');
+    expect(result.captionText).toBe('https://cdn.example.com/bare.jpg');
   });
 
-  it('collapses extra blank lines left by URL removal', () => {
-    const text = 'Line 1\n\nhttps://cdn.example.com/img.jpg\n\nLine 2';
+  it('collapses extra blank lines around an unwrapped wrapper', () => {
+    const text = 'Line 1\n\n\n![Img](https://cdn.example.com/img.jpg)\n\n\nLine 2';
     const result = extractMedia(text);
-    expect(result.captionText).toBe('Line 1\n\nLine 2');
+    expect(result.captionText).toBe(
+      'Line 1\n\nhttps://cdn.example.com/img.jpg\n\nLine 2'
+    );
   });
 
-  it('returns the full stripped text without truncation even when very long', () => {
+  it('returns the full caption without truncation even when very long', () => {
     const filler = 'a'.repeat(2000);
-    const text = `${filler} https://cdn.example.com/img.jpg trailing`;
+    const text = `${filler} ![X](https://cdn.example.com/img.jpg) trailing`;
     const result = extractMedia(text);
     expect(result.captionText.length).toBeGreaterThan(1024);
-    expect(result.captionText).toBe(`${filler}  trailing`);
+    expect(result.captionText).toBe(`${filler} https://cdn.example.com/img.jpg trailing`);
     expect(result.captionText.endsWith('…')).toBe(false);
   });
 
-  it('recognizes webp, gif, png for images', () => {
+  it('recognizes webp, gif, png for images when wrapped', () => {
     const text =
-      'A: https://cdn.example.com/a.webp B: https://cdn.example.com/b.gif C: https://cdn.example.com/c.png.';
+      'A: ![a](https://cdn.example.com/a.webp) B: ![b](https://cdn.example.com/b.gif) C: ![c](https://cdn.example.com/c.png).';
     const result = extractMedia(text);
     expect(result.attachments.map((a) => a.kind)).toEqual(['image', 'image', 'image']);
   });
 
-  it('recognizes mov and 3gp for videos', () => {
-    const text = 'A: https://cdn.example.com/a.mov B: https://cdn.example.com/b.3gp done.';
+  it('recognizes mov and 3gp for videos when wrapped', () => {
+    const text =
+      'A: [a](https://cdn.example.com/a.mov) B: [b](https://cdn.example.com/b.3gp) done.';
     const result = extractMedia(text);
     expect(result.attachments.map((a) => a.kind)).toEqual(['video', 'video']);
   });
 
-  it('unwraps `![alt](url.jpg)` markdown image into one attachment, dropping alt text from caption', () => {
+  it('unwraps `![alt](url.jpg)` into one attachment, dropping alt text but preserving the URL', () => {
     const text =
       "Here's the map:\n![Mount Tabor Map](https://cdn.example.com/map.jpg)\nClick for details.";
     const result = extractMedia(text);
     expect(result.attachments).toEqual([{ kind: 'image', url: 'https://cdn.example.com/map.jpg' }]);
-    expect(result.captionText).toBe("Here's the map:\n\nClick for details.");
+    expect(result.captionText).toBe(
+      "Here's the map:\nhttps://cdn.example.com/map.jpg\nClick for details."
+    );
     expect(result.captionText).not.toContain('Mount Tabor Map');
     expect(result.captionText).not.toContain('![');
     expect(result.captionText).not.toContain('](');
-    expect(result.captionText).not.toContain('https://');
   });
 
-  it('unwraps `[label](url.mp4)` markdown video link into one attachment, dropping label from caption', () => {
+  it('unwraps `[label](url.mp4)` into one attachment, dropping label but preserving the URL', () => {
     const text = 'Watch this:\n[Fishing Net](https://cdn.example.com/vid.mp4)\nEnjoy!';
     const result = extractMedia(text);
     expect(result.attachments).toEqual([{ kind: 'video', url: 'https://cdn.example.com/vid.mp4' }]);
-    expect(result.captionText).toBe('Watch this:\n\nEnjoy!');
+    expect(result.captionText).toBe(
+      'Watch this:\nhttps://cdn.example.com/vid.mp4\nEnjoy!'
+    );
     expect(result.captionText).not.toContain('Fishing Net');
     expect(result.captionText).not.toContain('[');
     expect(result.captionText).not.toContain('](');
-    expect(result.captionText).not.toContain('https://');
   });
 
   it('does not double the label when worker pre-labels image in prose', () => {
@@ -148,17 +139,19 @@ describe('extractMedia', () => {
     expect(result.attachments).toEqual([
       { kind: 'image', url: 'https://cdn.example.com/bread.jpg' },
     ]);
-    expect(result.captionText).toBe('Bread:\n\nMore prose.');
+    expect(result.captionText).toBe(
+      'Bread:\nhttps://cdn.example.com/bread.jpg\n\nMore prose.'
+    );
     expect(result.captionText).not.toMatch(/Bread\s+Bread/);
   });
 
-  it('unwraps `![](url.jpg)` with empty alt to just the URL — caption has no stray brackets or whitespace', () => {
+  it('unwraps `![](url.jpg)` with empty alt to just the URL — no stray brackets', () => {
     const text = 'Before\n![](https://cdn.example.com/bare.jpg)\nAfter';
     const result = extractMedia(text);
     expect(result.attachments).toEqual([
       { kind: 'image', url: 'https://cdn.example.com/bare.jpg' },
     ]);
-    expect(result.captionText).toBe('Before\n\nAfter');
+    expect(result.captionText).toBe('Before\nhttps://cdn.example.com/bare.jpg\nAfter');
     expect(result.captionText).not.toContain('[');
     expect(result.captionText).not.toContain(']');
   });
@@ -176,19 +169,65 @@ describe('extractMedia', () => {
     expect(result.attachments).toEqual([{ kind: 'video', url: 'https://cdn.example.com/vid.mp4' }]);
   });
 
-  it('extracts both a markdown-wrapped media link and a bare URL in order, dropping alt from caption', () => {
+  // Issue #28 acceptance cases — explicit attach-intent + bare-URL fallback contract.
+
+  it('does NOT extract a bare URL — only wrapped URLs become attachments', () => {
+    const text =
+      'Reference list:\nhttps://cdn.example.com/ref-image.jpg\nhttps://cdn.example.com/ref-video.mp4\nNothing should attach.';
+    const result = extractMedia(text);
+    expect(result.attachments).toEqual([]);
+    expect(result.captionText).toBe(text);
+  });
+
+  it('mixes wrapped and bare URLs: wrapped attaches, bare survives in caption verbatim', () => {
     const text =
       'First ![Map](https://cdn.example.com/a.jpg) then bare https://cdn.example.com/b.mp4 done.';
     const result = extractMedia(text);
     expect(result.attachments).toEqual([
       { kind: 'image', url: 'https://cdn.example.com/a.jpg' },
-      { kind: 'video', url: 'https://cdn.example.com/b.mp4' },
     ]);
-    expect(result.captionText).toContain('First');
-    expect(result.captionText).toContain('done.');
-    expect(result.captionText).not.toContain('Map');
-    expect(result.captionText).not.toContain('![');
-    expect(result.captionText).not.toContain('](');
-    expect(result.captionText).not.toContain('https://');
+    expect(result.captionText).toBe(
+      'First https://cdn.example.com/a.jpg then bare https://cdn.example.com/b.mp4 done.'
+    );
+  });
+
+  it('dedupes the same URL emitted in two wrappers — one attachment, both occurrences preserved in caption', () => {
+    const text =
+      '[Watch](https://cdn.example.com/v.mp4) and also [Open the video](https://cdn.example.com/v.mp4)';
+    const result = extractMedia(text);
+    expect(result.attachments).toEqual([
+      { kind: 'video', url: 'https://cdn.example.com/v.mp4' },
+    ]);
+    const occurrences = result.captionText.match(/https:\/\/cdn\.example\.com\/v\.mp4/g);
+    expect(occurrences).toHaveLength(2);
+  });
+
+  it('Aquifer linked-thumbnail `[![Thumb](thumb.jpg)](v.mp4)`: inner image attaches, outer video URL still survives in caption', () => {
+    // Documented limitation: the outer link's "label" contains brackets so the
+    // wrapper regex (`[^\]]*`) does not match it. Only the inner image is
+    // extracted as an attachment. The outer URL is unaffected by unwrap and
+    // therefore still appears in caption text — the silent-drop fallback
+    // still works.
+    const text = '[![Thumb](https://cdn.example.com/thumb.jpg)](https://cdn.example.com/v.mp4)';
+    const result = extractMedia(text);
+    expect(result.attachments).toEqual([
+      { kind: 'image', url: 'https://cdn.example.com/thumb.jpg' },
+    ]);
+    expect(result.captionText).toContain('https://cdn.example.com/thumb.jpg');
+    expect(result.captionText).toContain('https://cdn.example.com/v.mp4');
+  });
+
+  it('Mount Tabor end-to-end sample: 1 video + 2 images, all three URLs preserved in caption', () => {
+    const text =
+      'Here are the Mount Tabor videos for Matt 17:\n\n[Watch the Mount Tabor Video](https://s3.amazonaws.com/example/videos/a109/720p.mp4)\n\nAlso included:\n- 🗺️ ![Mount Tabor Map](https://cdn.example.com/map.jpg)\n- 📸 ![Photo of Mount Tabor](https://cdn.example.com/photo.jpg)';
+    const result = extractMedia(text);
+    expect(result.attachments).toEqual([
+      { kind: 'video', url: 'https://s3.amazonaws.com/example/videos/a109/720p.mp4' },
+      { kind: 'image', url: 'https://cdn.example.com/map.jpg' },
+      { kind: 'image', url: 'https://cdn.example.com/photo.jpg' },
+    ]);
+    expect(result.captionText).toContain('https://s3.amazonaws.com/example/videos/a109/720p.mp4');
+    expect(result.captionText).toContain('https://cdn.example.com/map.jpg');
+    expect(result.captionText).toContain('https://cdn.example.com/photo.jpg');
   });
 });


### PR DESCRIPTION
## Summary

- Switches `media-extractor.ts` from bare-URL detection to **explicit markdown-wrapper attach-intent**. Only `![alt](url)` / `[label](url)` patterns become attachments; bare URLs in worker output (reference lists, citations) pass through to the caption unchanged.
- Stops stripping the wrapped URL from the caption. The bare URL left behind by `unwrapMediaMarkdown` is now an **unconditional silent-drop fallback** — if Meta drops the attachment (e.g. an oversize video over its 16 MB cap), the user still has a clickable link in the caption text.
- `findAttachments` uses `MEDIA_MARKDOWN_REGEX` with a dedupe set; same URL emitted in two wrappers attaches once but both occurrences survive in caption.
- Removes the now-dead `MEDIA_REGEX` and `stripUrls` helpers.
- Updates the now-stale fallback comment in `message-handler.ts` (URL is no longer stripped, so the per-attachment retry-as-text is now belt-and-suspenders rather than load-bearing).
- Patch bump `1.3.2` → `1.3.3`.

## Why this approach

Production FIA video responses currently go silent on WhatsApp for anything over 16 MB. Earlier gateway-side HEAD-precheck (#23) was rejected on the security review (outbound fetch of LLM-derived URLs). Worker-side HEAD-precheck (worker #164) bakes Meta's per-consumer caps into the supposedly consumer-agnostic worker. This PR sidesteps both: no HEAD checks anywhere, no consumer-specific knowledge in the worker, and no dependency on Meta's delivery webhooks firing — the fallback is unconditional caption text.

## Test plan

- [x] `pnpm lint` clean (no new warnings)
- [x] `pnpm check` clean
- [x] `pnpm test` — 136/136 unit + e2e tests pass
- [x] Rewrote bare-URL tests around the new attach-intent contract
- [x] Added issue #28 acceptance cases: linked-thumbnail, dedup, mixed wrapped + bare, Mount Tabor end-to-end
- [ ] Live staging re-test once worker `bt-servant-worker#163` (canonical media markdown) ships: prompt *"pick a random one from fia"* — caption should contain clickable video URLs as text regardless of whether the attachment delivers.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)