### PR TITLE
(Claude) Multi-attachment caption fan-out (#30)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-whatsapp-gateway",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/services/message-handler.ts
+++ b/src/services/message-handler.ts
@@ -409,8 +409,18 @@ async function sendInCaptionMode(
   // N > 1: putting the prose-caption on attachment #1 only (the previous
   // behavior) leaves attachments #2..N context-less. Send the caption as a
   // standalone text message first, then ship every attachment captionless.
+  // The leading-text send is intentionally non-fatal: /progress-callback has
+  // already returned 200, so a thrown error here drops the entire batch with
+  // no engine retry. Better to deliver the attachments without the preamble
+  // than to silently lose the whole response.
   if (captionText.length > 0) {
-    await sendResponses(callback.user_id, [captionText], env);
+    try {
+      await sendResponses(callback.user_id, [captionText], env);
+    } catch (err) {
+      logger.warn('Leading caption text send failed; delivering attachments without preamble', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
   await sendRemainingAttachments(callback.user_id, attachments, env);
 }

--- a/src/services/message-handler.ts
+++ b/src/services/message-handler.ts
@@ -393,17 +393,26 @@ async function sendInCaptionMode(
 ): Promise<void> {
   const first = attachments[0];
   if (!first) return;
-  const firstSent = await sendOneAttachment(callback.user_id, first, captionText, env);
-  if (!firstSent) {
-    logger.warn('First media send failed, falling back to text', {
-      kind: first.kind,
-      url: redactUrl(first.url),
-    });
-    await sendResponses(callback.user_id, [callback.text ?? ''], env);
+  if (attachments.length === 1) {
+    const sent = await sendOneAttachment(callback.user_id, first, captionText, env);
+    if (!sent) {
+      logger.warn('First media send failed, falling back to text', {
+        kind: first.kind,
+        url: redactUrl(first.url),
+      });
+      await sendResponses(callback.user_id, [callback.text ?? ''], env);
+      return;
+    }
+    logger.info('Sent media attachment', { kind: first.kind, url: redactUrl(first.url) });
     return;
   }
-  logger.info('Sent media attachment', { kind: first.kind, url: redactUrl(first.url) });
-  await sendRemainingAttachments(callback.user_id, attachments.slice(1), env);
+  // N > 1: putting the prose-caption on attachment #1 only (the previous
+  // behavior) leaves attachments #2..N context-less. Send the caption as a
+  // standalone text message first, then ship every attachment captionless.
+  if (captionText.length > 0) {
+    await sendResponses(callback.user_id, [captionText], env);
+  }
+  await sendRemainingAttachments(callback.user_id, attachments, env);
 }
 
 async function sendInLongTextMode(

--- a/tests/unit/handle-callback-media.test.ts
+++ b/tests/unit/handle-callback-media.test.ts
@@ -77,24 +77,48 @@ describe('handleEngineCallback with inline media', () => {
     });
   });
 
-  it('sends two media messages with caption on first only when text wraps two URLs', async () => {
-    fetchMock.mockResolvedValueOnce({ ok: true }).mockResolvedValueOnce({ ok: true });
+  it('sends caption as standalone leading text + all attachments captionless when text wraps two URLs', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: true });
 
     const text =
       'Two things:\n![A](https://cdn.example.com/a.jpg)\n[B](https://cdn.example.com/b.mp4)\nDone.';
     await handleEngineCallback(baseCallback(text), mockEnv);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
 
-    const first = lastCallBody(fetchMock, 0);
-    expect(first.type).toBe('image');
-    expect((first.image as Record<string, unknown>).caption).toBe(
+    const leading = lastCallBody(fetchMock, 0);
+    expect(leading.type).toBe('text');
+    expect((leading.text as Record<string, unknown>).body).toBe(
       'Two things:\nhttps://cdn.example.com/a.jpg\nhttps://cdn.example.com/b.mp4\nDone.'
     );
 
     const second = lastCallBody(fetchMock, 1);
-    expect(second.type).toBe('video');
-    expect((second.video as Record<string, unknown>).caption).toBeUndefined();
+    expect(second.type).toBe('image');
+    expect((second.image as Record<string, unknown>).caption).toBeUndefined();
+
+    const third = lastCallBody(fetchMock, 2);
+    expect(third.type).toBe('video');
+    expect((third.video as Record<string, unknown>).caption).toBeUndefined();
+  });
+
+  it('leading text body is exactly the two URLs when multi-attachment input has no surrounding prose', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: true });
+
+    const text = '![](https://cdn.example.com/a.jpg) ![](https://cdn.example.com/b.jpg)';
+    await handleEngineCallback(baseCallback(text), mockEnv);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const leading = lastCallBody(fetchMock, 0);
+    expect(leading.type).toBe('text');
+    expect((leading.text as Record<string, unknown>).body).toBe(
+      'https://cdn.example.com/a.jpg https://cdn.example.com/b.jpg'
+    );
   });
 
   it('falls back to original text when the first (caption-bearing) media fails', async () => {
@@ -112,11 +136,11 @@ describe('handleEngineCallback with inline media', () => {
   });
 
   it('sends the URL as text when a later media fails, so the asset is not lost', async () => {
-    // First media succeeds with caption (which already contains both URLs as
-    // silent-drop fallback). Second media fails — we still send its URL as
-    // plain text. Redundant with the caption today, but cheap insurance for
-    // long-text mode where captions are not on the media itself.
+    // Multi-attachment flow: leading text (caption), image #1 (ok), video #2
+    // (fail), then the failed video's URL retried as plain text via
+    // sendRemainingAttachments fallback.
     fetchMock
+      .mockResolvedValueOnce({ ok: true })
       .mockResolvedValueOnce({ ok: true })
       .mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'Server Error' })
       .mockResolvedValueOnce({ ok: true });
@@ -125,23 +149,28 @@ describe('handleEngineCallback with inline media', () => {
       'Two things:\n![A](https://cdn.example.com/a.jpg)\n[B](https://cdn.example.com/b.mp4)\nDone.';
     await handleEngineCallback(baseCallback(text), mockEnv);
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
 
-    // First: image with caption (both URLs preserved in caption).
-    const first = lastCallBody(fetchMock, 0);
-    expect(first.type).toBe('image');
-    expect((first.image as Record<string, unknown>).caption).toBe(
+    // 1st: leading text with the full caption (both URLs preserved).
+    const leading = lastCallBody(fetchMock, 0);
+    expect(leading.type).toBe('text');
+    expect((leading.text as Record<string, unknown>).body).toBe(
       'Two things:\nhttps://cdn.example.com/a.jpg\nhttps://cdn.example.com/b.mp4\nDone.'
     );
 
-    // Second: failed video attempt.
-    const second = lastCallBody(fetchMock, 1);
-    expect(second.type).toBe('video');
+    // 2nd: image #1, captionless, ok.
+    const image = lastCallBody(fetchMock, 1);
+    expect(image.type).toBe('image');
+    expect((image.image as Record<string, unknown>).caption).toBeUndefined();
 
-    // Third: the URL of the failed media, sent as plain text.
-    const third = lastCallBody(fetchMock, 2);
-    expect(third.type).toBe('text');
-    expect((third.text as Record<string, unknown>).body).toBe('https://cdn.example.com/b.mp4');
+    // 3rd: failed video #2.
+    const failedVideo = lastCallBody(fetchMock, 2);
+    expect(failedVideo.type).toBe('video');
+
+    // 4th: the URL of the failed media, sent as plain text.
+    const fallback = lastCallBody(fetchMock, 3);
+    expect(fallback.type).toBe('text');
+    expect((fallback.text as Record<string, unknown>).body).toBe('https://cdn.example.com/b.mp4');
   });
 
   it('sends media captionless and full text (URL included) separately when caption exceeds 1024 chars', async () => {

--- a/tests/unit/handle-callback-media.test.ts
+++ b/tests/unit/handle-callback-media.test.ts
@@ -104,6 +104,37 @@ describe('handleEngineCallback with inline media', () => {
     expect((third.video as Record<string, unknown>).caption).toBeUndefined();
   });
 
+  it('still delivers all attachments when the leading text send fails (multi-attachment)', async () => {
+    // Reliability: /progress-callback returned 200 before this code runs, so a
+    // thrown error from the leading text send would drop the entire batch with
+    // no engine retry. The leading-text send must be non-fatal — attachments
+    // should still ship even if Meta rejected the preamble.
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'Server Error' })
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: true });
+
+    const text =
+      'Two things:\n![A](https://cdn.example.com/a.jpg)\n[B](https://cdn.example.com/b.mp4)\nDone.';
+    await handleEngineCallback(baseCallback(text), mockEnv);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    // 1st attempt: leading text (failed at Meta).
+    const leading = lastCallBody(fetchMock, 0);
+    expect(leading.type).toBe('text');
+
+    // 2nd: image #1, captionless, delivered despite the leading-text failure.
+    const image = lastCallBody(fetchMock, 1);
+    expect(image.type).toBe('image');
+    expect((image.image as Record<string, unknown>).caption).toBeUndefined();
+
+    // 3rd: video #2, captionless, also delivered.
+    const video = lastCallBody(fetchMock, 2);
+    expect(video.type).toBe('video');
+    expect((video.video as Record<string, unknown>).caption).toBeUndefined();
+  });
+
   it('leading text body is exactly the two URLs when multi-attachment input has no surrounding prose', async () => {
     fetchMock
       .mockResolvedValueOnce({ ok: true })


### PR DESCRIPTION
## Summary

When a worker response contains multiple media items, `sendInCaptionMode` previously put the full `captionText` on attachment #1 and shipped attachments #2..N captionless. Worker prompt PR `bt-servant-worker#168` ("one media item per response") was supposed to prevent this at the source, but as a soft prompt-level constraint it failed on staging today — *"all images from Matthew 4"* came back as a single 7-image response and the user saw one labeled image followed by 6 bare ones.

This is the structural gateway-side fix.

**New flow for `attachments.length > 1`:**
1. Send `captionText` as a standalone leading text message (skip if empty).
2. Send every attachment captionless via the existing `sendRemainingAttachments` helper.

**N=1 unchanged:** caption rides on the image; existing "first send fails → send full original text" safety net preserved.

Reuses `sendRemainingAttachments` verbatim — its per-attachment URL-as-text retry semantics carry over without change.

Patch bump `1.3.3` → `1.3.4`.

## Why Option A (and not per-image label slicing)

A more ambitious design would split `captionText` on URL anchors and attach a per-image slice to each attachment. That gives nicer per-image labels but assumes URL order in the caption matches `attachments[]` order, which breaks for the linked-thumbnail pattern and any worker output that lists URLs separately from descriptions. Option A is ~10 lines and never wrong; we can revisit slicing later if bare-image UX proves bad in practice.

## Scope

**In:** `sendInCaptionMode` and its tests.
**Out:** `sendInLongTextMode` (already sends captionless attachments + separate text — note its order is attachments-then-text, opposite of the new caption-mode multi-attachment order; worth aligning later but per the issue, not this PR), per-image label slicing, worker-side prompt enforcement.

## Test plan

- [x] `pnpm format`, `pnpm lint`, `pnpm check`, `pnpm format:check`, `pnpm test` — all clean
- [x] **137/137 unit + e2e tests pass** (was 136; added one new multi-attachment test)
- [x] Updated existing N=2 test to assert new shape (text first, then both captionless)
- [x] Updated "URL as text when later media fails" test for the new 4-send flow (text + image + failed video + URL fallback)
- [x] New test: leading text body equals exactly the joined URLs when input has no surrounding prose
- [x] N=1 single-attachment tests unchanged and still passing
- [ ] Live staging re-test post-merge: prompt *"all images from Matthew 4"* — expect one leading text message followed by N captionless images, all delivered cleanly

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)