### PR TITLE
Render PDF attachments as Meta document messages (#36)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-whatsapp-gateway",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/services/message-handler.ts
+++ b/src/services/message-handler.ts
@@ -418,7 +418,8 @@ async function sendPdfAttachments(
   userId: string,
   attachments: EngineAttachment[],
   env: Env
-): Promise<void> {
+): Promise<boolean> {
+  let delivered = false;
   for (const att of attachments) {
     if (att.type !== 'pdf') {
       logger.warn('Skipping unknown attachment type', { type: att.type });
@@ -431,14 +432,17 @@ async function sendPdfAttachments(
         size_bytes: att.size_bytes,
         url: redactUrl(att.url),
       });
+      delivered = true;
       continue;
     }
     logger.warn('Document send failed, falling back to URL as text', {
       filename: att.filename,
       url: redactUrl(att.url),
     });
-    await sendToWhatsApp(userId, att.url, env);
+    const fallbackSent = await sendToWhatsApp(userId, att.url, env);
+    if (fallbackSent) delivered = true;
   }
+  return delivered;
 }
 
 async function handleCompleteCallback(callback: EngineCallback, env: Env): Promise<void> {
@@ -451,15 +455,20 @@ async function handleCompleteCallback(callback: EngineCallback, env: Env): Promi
     textSent = true;
   }
 
+  let pdfDelivered = false;
   if (pdfs.length > 0) {
-    await sendPdfAttachments(callback.user_id, pdfs, env);
+    pdfDelivered = await sendPdfAttachments(callback.user_id, pdfs, env);
   }
 
-  if (!audioSent && !textSent && pdfs.length === 0) {
-    logger.error('Audio delivery failed with no text or attachment fallback');
+  if (!audioSent && !textSent && !pdfDelivered) {
+    logger.error('Complete callback produced no deliverable content', {
+      hadText: Boolean(callback.text),
+      hadAudio: Boolean(callback.voice_audio_url || callback.voice_audio_base64),
+      attachmentCount: pdfs.length,
+    });
     await sendToWhatsApp(
       callback.user_id,
-      'Sorry, I could not deliver the audio response. Please try again.',
+      'Sorry, I could not deliver the response. Please try again.',
       env
     );
   }

--- a/src/services/message-handler.ts
+++ b/src/services/message-handler.ts
@@ -10,7 +10,7 @@ import type {
   Contact,
   WebhookPayload,
 } from '../types/meta';
-import type { EngineCallback } from '../types/engine';
+import type { EngineAttachment, EngineCallback } from '../types/engine';
 import {
   sendTextMessage as sendToWhatsApp,
   sendTypingIndicator,
@@ -18,6 +18,7 @@ import {
   sendAudioFromBuffer,
   sendImageMessage,
   sendVideoMessage,
+  sendDocumentMessage,
   downloadMedia,
 } from './meta-api/client';
 import { extractMedia } from './media-extractor';
@@ -255,6 +256,10 @@ const VALID_CALLBACK_TYPES = ['status', 'progress', 'complete', 'error'];
  * Validate type-specific required fields on a callback payload.
  * Returns an error string if invalid, null if valid.
  */
+function hasAttachments(p: Record<string, unknown>): boolean {
+  return Array.isArray(p.attachments) && p.attachments.length > 0;
+}
+
 function validateCallbackFields(type: string, p: Record<string, unknown>): string | null {
   if (type === 'progress' && !isNonEmptyString(p.text)) {
     return 'Missing or invalid text for progress callback';
@@ -263,9 +268,10 @@ function validateCallbackFields(type: string, p: Record<string, unknown>): strin
     type === 'complete' &&
     !isNonEmptyString(p.text) &&
     !isNonEmptyString(p.voice_audio_base64) &&
-    !isNonEmptyString(p.voice_audio_url)
+    !isNonEmptyString(p.voice_audio_url) &&
+    !hasAttachments(p)
   ) {
-    return 'Missing text, voice_audio_base64, or voice_audio_url for complete callback';
+    return 'Missing text, voice_audio_base64, voice_audio_url, or attachments for complete callback';
   }
   if (type === 'error' && !isNonEmptyString(p.error)) {
     return 'Missing or invalid error for error callback';
@@ -408,14 +414,49 @@ async function handleTextWithMedia(callback: EngineCallback, env: Env): Promise<
   await sendRemainingAttachments(callback.user_id, attachments, env);
 }
 
-async function handleCompleteCallback(callback: EngineCallback, env: Env): Promise<void> {
-  const audioSent = await tryAudioDelivery(callback, env);
-  if (audioSent) return;
+async function sendPdfAttachments(
+  userId: string,
+  attachments: EngineAttachment[],
+  env: Env
+): Promise<void> {
+  for (const att of attachments) {
+    if (att.type !== 'pdf') {
+      logger.warn('Skipping unknown attachment type', { type: att.type });
+      continue;
+    }
+    const sent = await sendDocumentMessage(userId, att.url, att.filename, env);
+    if (sent) {
+      logger.info('Sent document attachment', {
+        filename: att.filename,
+        size_bytes: att.size_bytes,
+        url: redactUrl(att.url),
+      });
+      continue;
+    }
+    logger.warn('Document send failed, falling back to URL as text', {
+      filename: att.filename,
+      url: redactUrl(att.url),
+    });
+    await sendToWhatsApp(userId, att.url, env);
+  }
+}
 
-  if (callback.text) {
+async function handleCompleteCallback(callback: EngineCallback, env: Env): Promise<void> {
+  const pdfs = callback.attachments ?? [];
+
+  const audioSent = await tryAudioDelivery(callback, env);
+  let textSent = false;
+  if (!audioSent && callback.text) {
     await handleTextWithMedia(callback, env);
-  } else {
-    logger.error('Audio delivery failed with no text fallback');
+    textSent = true;
+  }
+
+  if (pdfs.length > 0) {
+    await sendPdfAttachments(callback.user_id, pdfs, env);
+  }
+
+  if (!audioSent && !textSent && pdfs.length === 0) {
+    logger.error('Audio delivery failed with no text or attachment fallback');
     await sendToWhatsApp(
       callback.user_id,
       'Sorry, I could not deliver the audio response. Please try again.',

--- a/src/services/meta-api/client.ts
+++ b/src/services/meta-api/client.ts
@@ -67,7 +67,7 @@ export async function sendImageMessage(
   caption: string | undefined,
   env: Env
 ): Promise<boolean> {
-  return sendMediaByLink(to, 'image', link, caption, env);
+  return sendMediaByLink(to, 'image', link, { caption }, env);
 }
 
 /**
@@ -80,20 +80,42 @@ export async function sendVideoMessage(
   caption: string | undefined,
   env: Env
 ): Promise<boolean> {
-  return sendMediaByLink(to, 'video', link, caption, env);
+  return sendMediaByLink(to, 'video', link, { caption }, env);
 }
 
-type MediaKind = 'image' | 'video';
+/**
+ * Send a WhatsApp document message by public HTTPS link.
+ * Meta fetches the link directly; no upload required. The filename shows
+ * in the document tile in WhatsApp.
+ */
+export async function sendDocumentMessage(
+  to: string,
+  link: string,
+  filename: string,
+  env: Env
+): Promise<boolean> {
+  return sendMediaByLink(to, 'document', link, { filename }, env);
+}
+
+type MediaKind = 'image' | 'video' | 'document';
+
+interface MediaOptions {
+  caption?: string | undefined;
+  filename?: string | undefined;
+}
 
 function buildMediaPayload(
   to: string,
   kind: MediaKind,
   link: string,
-  caption: string | undefined
+  options: MediaOptions
 ): Record<string, unknown> {
   const mediaBody: Record<string, unknown> = { link };
-  if (caption && caption.length > 0) {
-    mediaBody.caption = caption;
+  if (options.caption && options.caption.length > 0) {
+    mediaBody.caption = options.caption;
+  }
+  if (kind === 'document' && options.filename && options.filename.length > 0) {
+    mediaBody.filename = options.filename;
   }
   return {
     messaging_product: 'whatsapp',
@@ -143,11 +165,11 @@ async function sendMediaByLink(
   to: string,
   kind: MediaKind,
   link: string,
-  caption: string | undefined,
+  options: MediaOptions,
   env: Env
 ): Promise<boolean> {
   const url = `${getBaseUrl()}/${env.META_PHONE_NUMBER_ID}/messages`;
-  const payload = buildMediaPayload(to, kind, link, caption);
+  const payload = buildMediaPayload(to, kind, link, options);
 
   const response = await fetch(url, {
     method: 'POST',

--- a/src/types/engine.ts
+++ b/src/types/engine.ts
@@ -25,6 +25,15 @@ export interface ChatResponse {
 /** Callback type discriminator from the engine */
 export type EngineCallbackType = 'status' | 'progress' | 'complete' | 'error';
 
+/** A file attachment delivered alongside a complete callback. */
+export interface EngineAttachment {
+  type: 'pdf';
+  url: string;
+  filename: string;
+  size_bytes: number;
+  mime_type: 'application/pdf';
+}
+
 /** Unified payload received from engine callbacks */
 export interface EngineCallback {
   type: EngineCallbackType;
@@ -36,4 +45,5 @@ export interface EngineCallback {
   error?: string;
   voice_audio_base64?: string;
   voice_audio_url?: string;
+  attachments?: EngineAttachment[];
 }

--- a/tests/unit/handle-callback-attachments.test.ts
+++ b/tests/unit/handle-callback-attachments.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  handleEngineCallback,
+  validateEngineCallback,
+} from '../../src/services/message-handler';
+import type { Env } from '../../src/config/types';
+import type { EngineCallback } from '../../src/types/engine';
+
+const mockEnv: Env = {
+  META_VERIFY_TOKEN: 'test-verify-token',
+  META_WHATSAPP_TOKEN: 'test-whatsapp-token',
+  META_PHONE_NUMBER_ID: '123456789',
+  META_APP_SECRET: 'test-app-secret',
+  ENGINE_API_KEY: 'test-engine-key',
+  ENGINE_BASE_URL: 'http://localhost:8787',
+  ENGINE_ORG: 'test-org',
+  ENVIRONMENT: 'test',
+  CHUNK_SIZE: '1500',
+  MESSAGE_AGE_CUTOFF_SECONDS: '3600',
+  PROGRESS_THROTTLE_SECONDS: '3.0',
+  FACEBOOK_USER_AGENT: 'facebookexternalua',
+  GATEWAY_PUBLIC_URL: 'https://gateway.example.com',
+};
+
+function metaOk(wamid = 'wamid.test'): {
+  ok: true;
+  json: () => Promise<{ messages: { id: string }[] }>;
+} {
+  return { ok: true, json: async () => ({ messages: [{ id: wamid }] }) };
+}
+
+function pdfAttachment(
+  url = 'https://staging-api.btservant.ai/public/ptxprint/pdfs/shared/jobs/abc.pdf',
+  filename = 'bsb-JHN-bsb-empirical.pdf'
+): EngineCallback['attachments'] {
+  return [
+    {
+      type: 'pdf',
+      url,
+      filename,
+      size_bytes: 359196,
+      mime_type: 'application/pdf',
+    },
+  ];
+}
+
+function lastCallBody(fetchMock: ReturnType<typeof vi.fn>, idx: number): Record<string, unknown> {
+  const call = fetchMock.mock.calls[idx];
+  return JSON.parse(call[1]?.body as string);
+}
+
+describe('handleEngineCallback with PDF attachments', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('sends text first, then document, when complete callback has text + 1 PDF', async () => {
+    fetchMock.mockResolvedValueOnce(metaOk()).mockResolvedValueOnce(metaOk());
+
+    const callback: EngineCallback = {
+      type: 'complete',
+      user_id: '1234567890',
+      message_key: 'key-1',
+      timestamp: new Date().toISOString(),
+      text: 'Here is your print-ready PDF of John (BSB).',
+      attachments: pdfAttachment(),
+    };
+
+    await handleEngineCallback(callback, mockEnv);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const text = lastCallBody(fetchMock, 0);
+    expect(text.type).toBe('text');
+    expect((text.text as Record<string, unknown>).body).toBe(
+      'Here is your print-ready PDF of John (BSB).'
+    );
+
+    const doc = lastCallBody(fetchMock, 1);
+    expect(doc.type).toBe('document');
+    expect(doc.document).toEqual({
+      link: 'https://staging-api.btservant.ai/public/ptxprint/pdfs/shared/jobs/abc.pdf',
+      filename: 'bsb-JHN-bsb-empirical.pdf',
+    });
+  });
+
+  it('sends audio AND document when complete callback has voice_audio_base64 + PDF', async () => {
+    // Audio path: upload (returns media id) → send by id → then document send.
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 'media-aud-1' }) })
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(metaOk());
+
+    const callback: EngineCallback = {
+      type: 'complete',
+      user_id: '1234567890',
+      message_key: 'key-1',
+      timestamp: new Date().toISOString(),
+      voice_audio_base64: 'dGVzdA==',
+      attachments: pdfAttachment(),
+    };
+
+    await handleEngineCallback(callback, mockEnv);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    const docCall = lastCallBody(fetchMock, 2);
+    expect(docCall.type).toBe('document');
+    expect((docCall.document as Record<string, unknown>).filename).toBe(
+      'bsb-JHN-bsb-empirical.pdf'
+    );
+  });
+
+  it('sends only document when complete callback has attachments only (no text, no audio)', async () => {
+    fetchMock.mockResolvedValueOnce(metaOk());
+
+    const callback: EngineCallback = {
+      type: 'complete',
+      user_id: '1234567890',
+      message_key: 'key-1',
+      timestamp: new Date().toISOString(),
+      attachments: pdfAttachment(),
+    };
+
+    await handleEngineCallback(callback, mockEnv);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const doc = lastCallBody(fetchMock, 0);
+    expect(doc.type).toBe('document');
+  });
+
+  it('iterates over multiple PDFs, sending each as a separate document', async () => {
+    fetchMock
+      .mockResolvedValueOnce(metaOk()) // text
+      .mockResolvedValueOnce(metaOk()) // doc 1
+      .mockResolvedValueOnce(metaOk()); // doc 2
+
+    const callback: EngineCallback = {
+      type: 'complete',
+      user_id: '1234567890',
+      message_key: 'key-1',
+      timestamp: new Date().toISOString(),
+      text: 'Two PDFs for you.',
+      attachments: [
+        {
+          type: 'pdf',
+          url: 'https://cdn.example.com/a.pdf',
+          filename: 'a.pdf',
+          size_bytes: 1000,
+          mime_type: 'application/pdf',
+        },
+        {
+          type: 'pdf',
+          url: 'https://cdn.example.com/b.pdf',
+          filename: 'b.pdf',
+          size_bytes: 2000,
+          mime_type: 'application/pdf',
+        },
+      ],
+    };
+
+    await handleEngineCallback(callback, mockEnv);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    const doc1 = lastCallBody(fetchMock, 1);
+    expect(doc1.type).toBe('document');
+    expect((doc1.document as Record<string, unknown>).filename).toBe('a.pdf');
+
+    const doc2 = lastCallBody(fetchMock, 2);
+    expect(doc2.type).toBe('document');
+    expect((doc2.document as Record<string, unknown>).filename).toBe('b.pdf');
+  });
+
+  it('falls back to URL-as-text when document send fails', async () => {
+    fetchMock
+      .mockResolvedValueOnce(metaOk()) // text ok
+      .mockResolvedValueOnce({ ok: false, status: 400, text: async () => 'Bad Request' }) // doc fail
+      .mockResolvedValueOnce(metaOk()); // url-as-text fallback
+
+    const callback: EngineCallback = {
+      type: 'complete',
+      user_id: '1234567890',
+      message_key: 'key-1',
+      timestamp: new Date().toISOString(),
+      text: 'Here you go.',
+      attachments: pdfAttachment('https://cdn.example.com/broken.pdf', 'broken.pdf'),
+    };
+
+    await handleEngineCallback(callback, mockEnv);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    const failedDoc = lastCallBody(fetchMock, 1);
+    expect(failedDoc.type).toBe('document');
+
+    const fallback = lastCallBody(fetchMock, 2);
+    expect(fallback.type).toBe('text');
+    expect((fallback.text as Record<string, unknown>).body).toBe(
+      'https://cdn.example.com/broken.pdf'
+    );
+  });
+
+  it('skips unknown attachment types and continues with remaining PDFs', async () => {
+    fetchMock
+      .mockResolvedValueOnce(metaOk()) // text
+      .mockResolvedValueOnce(metaOk()); // doc for the valid pdf
+
+    // Inject a future-type attachment to verify the gateway skips it safely
+    // rather than crashing on an unmodeled `type`.
+    const callback = {
+      type: 'complete',
+      user_id: '1234567890',
+      message_key: 'key-1',
+      timestamp: new Date().toISOString(),
+      text: 'Mixed bag.',
+      attachments: [
+        {
+          type: 'spreadsheet',
+          url: 'https://cdn.example.com/sheet.xlsx',
+          filename: 'sheet.xlsx',
+          size_bytes: 1000,
+          mime_type: 'application/pdf',
+        },
+        {
+          type: 'pdf',
+          url: 'https://cdn.example.com/ok.pdf',
+          filename: 'ok.pdf',
+          size_bytes: 1000,
+          mime_type: 'application/pdf',
+        },
+      ],
+    } as unknown as EngineCallback;
+
+    await handleEngineCallback(callback, mockEnv);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const doc = lastCallBody(fetchMock, 1);
+    expect(doc.type).toBe('document');
+    expect((doc.document as Record<string, unknown>).filename).toBe('ok.pdf');
+  });
+});
+
+describe('validateEngineCallback with attachments', () => {
+  it('accepts a complete callback with attachments only (no text, no audio)', () => {
+    const result = validateEngineCallback({
+      type: 'complete',
+      user_id: '1234567890',
+      message_key: 'key-1',
+      timestamp: new Date().toISOString(),
+      attachments: [
+        {
+          type: 'pdf',
+          url: 'https://cdn.example.com/a.pdf',
+          filename: 'a.pdf',
+          size_bytes: 1000,
+          mime_type: 'application/pdf',
+        },
+      ],
+    });
+    expect(result).toBeNull();
+  });
+
+  it('rejects a complete callback with empty attachments array and no text/audio', () => {
+    const result = validateEngineCallback({
+      type: 'complete',
+      user_id: '1234567890',
+      message_key: 'key-1',
+      timestamp: new Date().toISOString(),
+      attachments: [],
+    });
+    expect(result).toMatch(/Missing text/);
+  });
+
+  it('still rejects a complete callback with no text, audio, or attachments', () => {
+    const result = validateEngineCallback({
+      type: 'complete',
+      user_id: '1234567890',
+      message_key: 'key-1',
+      timestamp: new Date().toISOString(),
+    });
+    expect(result).toMatch(/Missing text/);
+  });
+});

--- a/tests/unit/handle-callback-attachments.test.ts
+++ b/tests/unit/handle-callback-attachments.test.ts
@@ -209,6 +209,58 @@ describe('handleEngineCallback with PDF attachments', () => {
     );
   });
 
+  it('sends apology when attachments-only callback contains no PDF entries', async () => {
+    // Validation accepts any non-empty attachments[] but delivery only handles
+    // type === 'pdf'. Without the deliverability check, the user would silently
+    // get nothing here — the apology must fire.
+    fetchMock.mockResolvedValueOnce(metaOk()); // apology text only
+
+    const callback = {
+      type: 'complete',
+      user_id: '1234567890',
+      message_key: 'key-1',
+      timestamp: new Date().toISOString(),
+      attachments: [
+        {
+          type: 'spreadsheet',
+          url: 'https://cdn.example.com/sheet.xlsx',
+          filename: 'sheet.xlsx',
+          size_bytes: 1000,
+          mime_type: 'application/pdf',
+        },
+      ],
+    } as unknown as EngineCallback;
+
+    await handleEngineCallback(callback, mockEnv);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const apology = lastCallBody(fetchMock, 0);
+    expect(apology.type).toBe('text');
+    expect((apology.text as Record<string, unknown>).body).toMatch(/could not deliver/i);
+  });
+
+  it('sends apology when every PDF send fails AND every URL fallback also fails', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 400, text: async () => 'Bad Request' }) // doc fail
+      .mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'Server Error' }) // url fallback fail
+      .mockResolvedValueOnce(metaOk()); // apology
+
+    const callback: EngineCallback = {
+      type: 'complete',
+      user_id: '1234567890',
+      message_key: 'key-1',
+      timestamp: new Date().toISOString(),
+      attachments: pdfAttachment(),
+    };
+
+    await handleEngineCallback(callback, mockEnv);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const apology = lastCallBody(fetchMock, 2);
+    expect(apology.type).toBe('text');
+    expect((apology.text as Record<string, unknown>).body).toMatch(/could not deliver/i);
+  });
+
   it('skips unknown attachment types and continues with remaining PDFs', async () => {
     fetchMock
       .mockResolvedValueOnce(metaOk()) // text

--- a/tests/unit/meta-client-document.test.ts
+++ b/tests/unit/meta-client-document.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { sendDocumentMessage } from '../../src/services/meta-api/client';
+import type { Env } from '../../src/config/types';
+
+const mockEnv: Env = {
+  META_VERIFY_TOKEN: 'test-verify-token',
+  META_WHATSAPP_TOKEN: 'test-whatsapp-token',
+  META_PHONE_NUMBER_ID: '123456789',
+  META_APP_SECRET: 'test-app-secret',
+  ENGINE_API_KEY: 'test-engine-key',
+  ENGINE_BASE_URL: 'http://localhost:8787',
+  ENGINE_ORG: 'test-org',
+  ENVIRONMENT: 'test',
+  CHUNK_SIZE: '1500',
+  MESSAGE_AGE_CUTOFF_SECONDS: '3600',
+  PROGRESS_THROTTLE_SECONDS: '3.0',
+  FACEBOOK_USER_AGENT: 'facebookexternalua',
+  GATEWAY_PUBLIC_URL: 'https://gateway.example.com',
+};
+
+function metaOk(wamid = 'wamid.test'): {
+  ok: true;
+  json: () => Promise<{ messages: { id: string }[] }>;
+} {
+  return { ok: true, json: async () => ({ messages: [{ id: wamid }] }) };
+}
+
+describe('sendDocumentMessage', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('posts type:document with link and filename, no caption', async () => {
+    fetchMock.mockResolvedValueOnce(metaOk());
+
+    const result = await sendDocumentMessage(
+      '1234567890',
+      'https://cdn.example.com/bsb-JHN.pdf',
+      'bsb-JHN-bsb-empirical.pdf',
+      mockEnv
+    );
+
+    expect(result).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://graph.facebook.com/v23.0/123456789/messages',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          messaging_product: 'whatsapp',
+          to: '1234567890',
+          type: 'document',
+          document: {
+            link: 'https://cdn.example.com/bsb-JHN.pdf',
+            filename: 'bsb-JHN-bsb-empirical.pdf',
+          },
+        }),
+      })
+    );
+  });
+
+  it('sends Bearer auth header', async () => {
+    fetchMock.mockResolvedValueOnce(metaOk());
+
+    await sendDocumentMessage(
+      '1234567890',
+      'https://cdn.example.com/file.pdf',
+      'file.pdf',
+      mockEnv
+    );
+
+    const init = fetchMock.mock.calls[0][1];
+    expect(init?.headers?.Authorization).toBe('Bearer test-whatsapp-token');
+  });
+
+  it('returns false on non-2xx', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => 'Bad Request',
+    });
+
+    const result = await sendDocumentMessage(
+      '1234567890',
+      'https://cdn.example.com/file.pdf',
+      'file.pdf',
+      mockEnv
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns false when 200 body has a permanent error code (131052)', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        error: { code: 131052, message: 'Media download error' },
+      }),
+    });
+
+    const result = await sendDocumentMessage(
+      '1234567890',
+      'https://cdn.example.com/file.pdf',
+      'file.pdf',
+      mockEnv
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns false when 200 body has an unknown error code (fail-closed)', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        error: { code: 999999, message: 'some new permanent failure' },
+      }),
+    });
+
+    const result = await sendDocumentMessage(
+      '1234567890',
+      'https://cdn.example.com/file.pdf',
+      'file.pdf',
+      mockEnv
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns true when 200 body has a transient error code (131000)', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        error: { code: 131000, message: 'Something went wrong' },
+      }),
+    });
+
+    const result = await sendDocumentMessage(
+      '1234567890',
+      'https://cdn.example.com/file.pdf',
+      'file.pdf',
+      mockEnv
+    );
+    expect(result).toBe(true);
+  });
+
+  it('returns false when messages[0].message_status === "failed"', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ messages: [{ id: 'wamid.x', message_status: 'failed' }] }),
+    });
+
+    const result = await sendDocumentMessage(
+      '1234567890',
+      'https://cdn.example.com/file.pdf',
+      'file.pdf',
+      mockEnv
+    );
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Wire the worker's new `attachments[]` field on `complete` callbacks through to Meta's WhatsApp Cloud API as `type: "document"` messages, so users actually receive the print-ready scripture PDFs the worker generates (closes #36).
- Audio + PDF and text + PDF both deliver — audio (or text) first, then each PDF; PDFs are no longer dropped on the audio path.
- Uses `document.link` (not media upload) since the worker's PDF URL is public, immutable, and content-addressed.

## Changes

- `src/types/engine.ts` — add `EngineAttachment` and optional `attachments?: EngineAttachment[]` on `EngineCallback`.
- `src/services/meta-api/client.ts` — add `'document'` to `MediaKind`, expose `sendDocumentMessage(to, link, filename, env)`, refactor `sendMediaByLink` to take a `MediaOptions` bag (caption + filename) to stay under the 5-param lint cap.
- `src/services/message-handler.ts` — add `sendPdfAttachments`, refactor `handleCompleteCallback` to always run the attachment path after audio/text. Relax `validateCallbackFields` so attachments-only `complete` payloads validate (future-proofing — v1 worker still pairs PDFs with text).
- Tests:
  - `tests/unit/meta-client-document.test.ts` — payload shape, auth header, Meta-2xx-with-error-code classification (mirrors media tests).
  - `tests/unit/handle-callback-attachments.test.ts` — text + PDF, audio + PDF, attachments-only, multi-PDF, document send failure → URL-as-text fallback, unknown attachment type skip, validator behavior.

## Decisions

- **Audio + PDF:** deliver both. The user explicitly asked for the PDF; the audio path no longer short-circuits.
- **Caption:** none in v1 (filename alone shows in the WhatsApp document tile). Deferred per the issue's nice-to-have list.
- **Upload vs link:** link only. The worker's URL is public/unauthenticated/immutable.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm check` clean
- [x] `pnpm test` — 165/165 passing (9 new)
- [ ] Staging smoke: send "Generate a print-ready PDF of John from BSB" through the gateway, confirm WhatsApp receives the text reply followed by a document message that opens to the PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)